### PR TITLE
Preset stats

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -384,6 +384,9 @@ type ItemPropertiesPainkiller {
 
 type ItemPropertiesPreset {
   baseItem: Item!
+  ergonomics: Float
+  recoilVertical: Int
+  recoilHorizontal: Int
 }
 
 type ItemPropertiesScope {
@@ -418,6 +421,12 @@ type ItemPropertiesWeapon {
   recoilHorizontal: Int
   repairCost: Int
   sightingRange: Int
+  defaultWidth: Int
+  defaultHeight: Int
+  defaultErgonomics: Float,
+  defaultRecoilVertical: Int
+  defaultRecoilHorizontal: Int
+  defaultWeight: Float
 }
 
 type ItemPropertiesWeaponMod {


### PR DESCRIPTION
Adds stats like width, height, ergo, recoil, and weight to weapon and preset item properties.