### PR TITLE
fix trader name translation on TraderOffer

### DIFF
--- a/resolvers/traderResolver.js
+++ b/resolvers/traderResolver.js
@@ -49,8 +49,8 @@ module.exports = {
         }
     },
     TraderOffer: {
-        async name(data, args, context) {
-            return (await context.data.trader.get(data.trader_id)).name;
+        async name(data, args, context, info) {
+            return context.util.getLocale(await context.data.trader.get(data.trader_id), 'name', info);
         },
         trader(data, args, context) {
             return context.data.trader.get(data.trader_id);

--- a/schema.js
+++ b/schema.js
@@ -791,6 +791,7 @@ type TaskStatusRequirement {
 type Trader {
   id: ID!
   name: String!
+  normalizedName: String!
   resetTime: String
   currency: Item!
   discount: Float!


### PR DESCRIPTION
The name attribute on the TraderOffer type was not correctly returning the requested translation.

Also adds normalizedName to traders.