### PR TITLE
add normalizedName to FleaMarket type

### DIFF
--- a/schema.js
+++ b/schema.js
@@ -130,6 +130,7 @@ type GameProperty {
 
 type FleaMarket implements Vendor {
   name: String!
+  normalizedName: String!
   minPlayerLevel: Int!
   enabled: Boolean!
   sellOfferFeeRate: Float!


### PR DESCRIPTION
# add normalizedName to FleaMarket type

This PR adds the `normalizedName` field to the `FleaMarket` type. I'm unsure if this will work but going to try it out

resolves: https://github.com/the-hideout/tarkov-api/issues/78