### PR TITLE
Query cache kv

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,7 +8,7 @@ webpack_config = "webpack.config.js"
 routes = ["api.tarkov.dev/graphql", "api.tarkov.dev/graphql*", "api.tarkov.dev/___graphql", "api.tarkov.dev/webhook*"]
 kv-namespaces = [
     { binding = "DATA_CACHE", id = "2e6feba88a9e4097b6d2209191ed4ae5", preview_id = "17fd725f04984e408d4a70b37c817171" },
-    { binding = "QUERY_CACHE", id = "7ae67967cff24ceaa31ca58c5a6da798", preview_id = "cf717460f7eb40299a0f8f844d157051" }
+    { binding = "QUERY_CACHE", id = "cf717460f7eb40299a0f8f844d157051", preview_id = "cf717460f7eb40299a0f8f844d157051" }
 ]
 vars = { ENVIRONMENT = "production" }
 


### PR DESCRIPTION
Changes the ID for the query cache KV as deleting the existing KV might be necessary according to Cloudflare support. I don't want us to delete the KV and then have the API start failing because it doesn't exist anymore.