### PR TITLE
Don't cache responses with errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,8 @@ async function graphqlHandler(event, graphQLOptions) {
     const body = JSON.stringify(result);
 
     // Update the cache with the results of the query
-    if (!skipCache) {
+    // don't update cache if result contained errors
+    if (!skipCache && (!result.errors || result.errors.length === 0)) {
         // using waitUntil doens't hold up returning a response but keeps the worker alive as long as needed
         event.waitUntil(cacheMachine.put(query, body));
     }

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ async function graphqlHandler(event, graphQLOptions) {
 
     // Check the cache service for data first - If cached data exists, return it
     if (!skipCache) {
-        const cachedResponse = await cacheMachine.get(query);
+        const cachedResponse = await cacheMachine.get(query, variables);
         if (cachedResponse) {
             // Construct a new response with the cached data
             const newResponse = new Response(cachedResponse, headers);
@@ -173,7 +173,7 @@ async function graphqlHandler(event, graphQLOptions) {
     // don't update cache if result contained errors
     if (!skipCache && (!result.errors || result.errors.length === 0)) {
         // using waitUntil doens't hold up returning a response but keeps the worker alive as long as needed
-        event.waitUntil(cacheMachine.put(query, body));
+        event.waitUntil(cacheMachine.put(query, variables, body));
     }
 
     /* if(!result.errors && !url.hostname.includes('localhost') && !url.hostname.includes('tutorial.cloudflareworkers.com')){

--- a/schema.js
+++ b/schema.js
@@ -155,6 +155,7 @@ type HealthEffect {
 type HideoutStation {
   id: ID!
   name: String!
+  normalizedName: String!
   levels: [HideoutStationLevel]!
   tarkovDataId: Int
   "crafts is only available via the hideoutStations query."

--- a/utils/cache-machine.js
+++ b/utils/cache-machine.js
@@ -23,11 +23,11 @@ async function hash(string) {
 // :param json: the incoming request in json
 // :param body: the body to cache
 // :return: true if successful, false if not
-async function updateCache(query, body) {
+async function updateCache(query, variables, body) {
     try {
         // Get the cacheKey from the request
         query = query.trim();
-        const cacheKey = await hash(query);
+        const cacheKey = await hash(query+JSON.stringify(variables));
 
         // headers and POST body
         const headersPost = {
@@ -55,10 +55,10 @@ async function updateCache(query, body) {
 // Checks the caching service to see if a request has been cached
 // :param json: the json payload of the incoming worker request
 // :return: json results of the item found in the cache or false if not found
-async function checkCache(query) {
+async function checkCache(query, variables) {
     try {
         query = query.trim();
-        const cacheKey = await hash(query);
+        const cacheKey = await hash(query+JSON.stringify(variables));
 
         const response = await fetch(`${cacheUrl}/api/cache?key=${cacheKey}`, {headers: headers});
         if (response.status === 200) {


### PR DESCRIPTION
Also adds the variables to the query string for hashing so that identical queries using different variables are cached separately.