### PR TITLE
allow different lang settings for multi queries

### DIFF
--- a/utils/graphql-util.js
+++ b/utils/graphql-util.js
@@ -21,7 +21,8 @@ module.exports = {
         }
         for (const selection of info.operation.selectionSet.selections) {
             let selectionRoot = selection.name.value;
-            if (selection.alias) selectionRoot = selection.alias.value;
+            if (selection.alias)
+                selectionRoot = selection.alias.value;
             if (selectionRoot !== myRoot) continue;
             for (const arg of selection.arguments) {
                 if (arg.name.value === 'lang') {

--- a/utils/graphql-util.js
+++ b/utils/graphql-util.js
@@ -23,7 +23,8 @@ module.exports = {
             let selectionRoot = selection.name.value;
             if (selection.alias)
                 selectionRoot = selection.alias.value;
-            if (selectionRoot !== myRoot) continue;
+            if (selectionRoot !== myRoot)
+                continue;
             for (const arg of selection.arguments) {
                 if (arg.name.value === 'lang') {
                     lang = arg.value.value;

--- a/utils/graphql-util.js
+++ b/utils/graphql-util.js
@@ -15,7 +15,14 @@ module.exports = {
     getLang: (info) => {
         let lang = 'en';
         let langFound = false;
+        let myRoot = info.path.key;
+        for (let currentNode = info.path.prev; currentNode; currentNode = currentNode.prev) {
+            myRoot = currentNode.key;
+        }
         for (const selection of info.operation.selectionSet.selections) {
+            let selectionRoot = selection.name.value;
+            if (selection.alias) selectionRoot = selection.alias.value;
+            if (selectionRoot !== myRoot) continue;
             for (const arg of selection.arguments) {
                 if (arg.name.value === 'lang') {
                     lang = arg.value.value;


### PR DESCRIPTION
Currently, if a user executes multiple queries in a single API request, the lang setting for the first query overrides any lang settings for the following queries. This fixes that so each query can have its own lang argument.