### PR TITLE
Update retrieved kv after 5 minutes

### DIFF
--- a/datasources/hideout.js
+++ b/datasources/hideout.js
@@ -3,6 +3,7 @@ const WorkerKV = require('../utils/worker-kv');
 class HideoutAPI extends WorkerKV {
     constructor() {
         super('hideout_data');
+        this.refreshInterval = 1000 * 60 * 10;
     }
 
     async getList() {

--- a/datasources/historical-prices.js
+++ b/datasources/historical-prices.js
@@ -3,6 +3,7 @@ const WorkerKV = require('../utils/worker-kv');
 class historicalPricesAPI extends WorkerKV {
     constructor() {
         super('historical_price_data');
+        this.refreshInterval = 1000 * 60 * 30;
     }
 
     async getByItemId(itemId) {

--- a/datasources/maps.js
+++ b/datasources/maps.js
@@ -3,6 +3,7 @@ const WorkerKV = require('../utils/worker-kv');
 class MapAPI extends WorkerKV {
     constructor() {
         super('map_data');
+        this.refreshInterval = 1000 * 60 * 20;
     }
 
     async getList() {

--- a/datasources/tasks.js
+++ b/datasources/tasks.js
@@ -3,6 +3,7 @@ const WorkerKV = require('../utils/worker-kv');
 class TasksAPI extends WorkerKV {
     constructor() {
         super('quest_data');
+        this.refreshInterval = 1000 * 60 * 10;
     }
 
     async getList() {

--- a/datasources/trader-inventory.js
+++ b/datasources/trader-inventory.js
@@ -4,6 +4,7 @@ class TraderInventoryAPI extends WorkerKV {
     constructor() {
         super('trader_price_data');
         this.traderCache = false;
+        this.refreshInterval = 1000 * 60 * 60 * 12;
     }
 
     async initTraderCache() {

--- a/utils/worker-kv.js
+++ b/utils/worker-kv.js
@@ -16,7 +16,6 @@ class WorkerKV {
             return;
         }
         if (this.cache) {
-            console.log('getting new data')
             this.cache = false;
         }
         if (this.loading) {

--- a/utils/worker-kv.js
+++ b/utils/worker-kv.js
@@ -7,11 +7,15 @@ class WorkerKV {
         this.kvName = kvName;
         this.loadingPromises = [];
         this.loadingInterval = false;
+        this.retrieveDate = new Date (0);
     }
 
     async init() {
-        if (this.cache) {
+        if (this.cache && new Date() - this.retrieveDate < 1000 * 60 * 5) {
             return;
+        }
+        if (this.cache) {
+            this.cache = false;
         }
         if (this.loading) {
             return new Promise((resolve) => {
@@ -40,6 +44,7 @@ class WorkerKV {
                 } else {
                     this.cache = JSON.parse(data);
                 }
+                this.retrieveDate = new Date();
                 this.loading = false;
                 resolve();
             }).catch(error => {

--- a/utils/worker-kv.js
+++ b/utils/worker-kv.js
@@ -7,14 +7,16 @@ class WorkerKV {
         this.kvName = kvName;
         this.loadingPromises = [];
         this.loadingInterval = false;
-        this.retrieveDate = new Date (0);
+        this.dataUpdated = new Date (0);
+        this.refreshInterval = 1000 * 60 * 5;
     }
 
     async init() {
-        if (this.cache && new Date() - this.retrieveDate < 1000 * 60 * 5) {
+        if (this.cache && new Date() - this.dataUpdated < this.refreshInterval + 60000) {
             return;
         }
         if (this.cache) {
+            console.log('getting new data')
             this.cache = false;
         }
         if (this.loading) {
@@ -44,7 +46,10 @@ class WorkerKV {
                 } else {
                     this.cache = JSON.parse(data);
                 }
-                this.retrieveDate = new Date();
+                this.dataUpdated = new Date();
+                if (this.cache.updated) {
+                    this.dataUpdated = new Date(this.cache.updated);
+                }
                 this.loading = false;
                 resolve();
             }).catch(error => {


### PR DESCRIPTION
Currently, a worker only retrieves data from a KV once. If that worker persists, then it won't ever update the KV data. This update ensures that workers will request new KV data if the last retrieval was more than 5 minutes ago.