### PR TITLE
Adds error for requests missing content-type

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,9 +133,7 @@ async function graphqlHandler(event, graphQLOptions) {
     if (!contentType || !contentType.startsWith('application/json')) {
         specialCache = 'application/json';
     }
-    /*if (!contentType?.startsWith('application/json')) {
 
-    }*/
     const requestId = uuidv4();
     console.info(requestId);
     console.log(new Date().toLocaleString('en-US', { timeZone: 'UTC' }));

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ async function graphqlHandler(event, graphQLOptions) {
     }
 
     // default headers
-    const headers = {
+    const responseOptions = {
         headers: {
             'content-type': 'application/json;charset=UTF-8',
         }
@@ -146,7 +146,7 @@ async function graphqlHandler(event, graphQLOptions) {
         const cachedResponse = await cacheMachine.get(query, variables, specialCache);
         if (cachedResponse) {
             // Construct a new response with the cached data
-            const newResponse = new Response(cachedResponse, headers);
+            const newResponse = new Response(cachedResponse, responseOptions);
             // Add a custom 'X-CACHE: HIT' header so we know the request hit the cache
             newResponse.headers.append('X-CACHE', 'HIT');
             console.log(`Request served from cache: ${new Date() - requestStart} ms`);
@@ -181,11 +181,7 @@ async function graphqlHandler(event, graphQLOptions) {
     console.log(`Response time: ${new Date() - requestStart} ms`);
     //console.log(`${requestId} kvs loaded: ${dataAPI.requests[requestId].kvLoaded.join(', ')}`);
     delete dataAPI.requests[requestId];
-    return new Response(body, {
-        headers: {
-            'content-type': 'application/json',
-        },
-    });
+    return new Response(body, responseOptions);
 }
 
 const graphQLOptions = {

--- a/index.js
+++ b/index.js
@@ -164,8 +164,8 @@ async function graphqlHandler(event, graphQLOptions) {
         if (!result.errors) {
             result = Object.assign({errors: []}, result);
         }
-        result.errors.push('You must supply a content-type header with your request. Requests missing this header are limited to a request cache that updates every 15 minutes.');
         ttl = String(15 * 60);
+        result.errors.push(`Your request does not have a "content-type" header set to "application/json". Requests missing this header are limited to a request cache that updates every ${parseInt(ttl)/60} minutes.`);
     }
 
     const body = JSON.stringify(result);

--- a/index.js
+++ b/index.js
@@ -169,13 +169,6 @@ async function graphqlHandler(event, graphQLOptions) {
         result.errors.push('You must supply a content-type header with your request. Requests missing this header are limited to a request cache that updates every 15 minutes.');
         ttl = String(15 * 60);
     }
-    if (specialCache) {
-        result.data2 = result.data;
-        delete result.data;
-        result.data = result.data2;
-        delete result.data2;
-    }
-    console.log(JSON.stringify(result.errors, null, 4));
 
     const body = JSON.stringify(result);
 

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ async function graphqlHandler(event, graphQLOptions) {
             result = Object.assign({errors: []}, result);
         }
         ttl = String(15 * 60);
-        result.errors.push(`Your request does not have a "content-type" header set to "application/json". Requests missing this header are limited to a request cache that updates every ${parseInt(ttl)/60} minutes.`);
+        result.errors.push(`Your request does not have a "content-type" header set to "application/json". Requests missing this header are limited to resposnes that update every ${parseInt(ttl)/60} minutes.`);
     }
 
     const body = JSON.stringify(result);

--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ async function graphqlHandler(event, graphQLOptions) {
     } else {
         return new Response(null, {
             status: 501,
+            headers: { 'cache-control': 'public, max-age=2592000' }
         });
     }
     // Check for empty /graphql query

--- a/utils/cache-machine.js
+++ b/utils/cache-machine.js
@@ -56,11 +56,6 @@ async function updateCache(query, variables, body, ttl = '', specialCache = '') 
         console.log(`caching response for ${ENVIRONMENT} environment`);
         const cacheKey = await hash(ENVIRONMENT + query + JSON.stringify(variables) + specialCache);
 
-        //set special cache timers for special caches
-        if (specialCache === 'application/json') {
-            //ttl = '900';
-        }
-
         // headers and POST body
         const headersPost = {
             body: JSON.stringify({ key: cacheKey, value: body, ttl }),

--- a/utils/cache-machine.js
+++ b/utils/cache-machine.js
@@ -45,7 +45,7 @@ async function hash(string) {
 // :param json: the incoming request in json
 // :param body: the body to cache
 // :return: true if successful, false if not
-async function updateCache(query, variables, body, ttl = '') {
+async function updateCache(query, variables, body, ttl = '', specialCache = '') {
     try {
         if (cachePaused) {
             console.warn('Cache paused; skipping cache update');
@@ -54,7 +54,12 @@ async function updateCache(query, variables, body, ttl = '') {
         // Get the cacheKey from the request
         query = query.trim();
         console.log(`caching response for ${ENVIRONMENT} environment`);
-        const cacheKey = await hash(ENVIRONMENT + query + JSON.stringify(variables));
+        const cacheKey = await hash(ENVIRONMENT + query + JSON.stringify(variables) + specialCache);
+
+        //set special cache timers for special caches
+        if (specialCache === 'application/json') {
+            //ttl = '900';
+        }
 
         // headers and POST body
         const headersPost = {
@@ -88,14 +93,14 @@ async function updateCache(query, variables, body, ttl = '') {
 // Checks the caching service to see if a request has been cached
 // :param json: the json payload of the incoming worker request
 // :return: json results of the item found in the cache or false if not found
-async function checkCache(query, variables) {
+async function checkCache(query, variables, specialCache = '') {
     try {
         if (cachePaused) {
             console.warn('Cache paused; skipping cache check');
             return false;
         }
         query = query.trim();
-        const cacheKey = await hash(ENVIRONMENT + query + JSON.stringify(variables));
+        const cacheKey = await hash(ENVIRONMENT + query + JSON.stringify(variables) + specialCache);
         if (!cacheKey) {
             console.warn('Skipping cache check; key is empty');
             return false;


### PR DESCRIPTION
Any requests missing the proper content-type header are given an error telling them to set the header and that their requests are cached for 15 minutes:
![image](https://user-images.githubusercontent.com/35779878/217535347-e5f3e462-4bc7-49ef-9b2d-70f5ddc4733b.png)

If they're not checking for errors, they can continue using the response as they have been. If they are checking for errors, they will see instructions on how to fix it.