### PR TITLE
Limit historical prices on Item object

### DIFF
--- a/datasources/historical-prices.js
+++ b/datasources/historical-prices.js
@@ -5,12 +5,15 @@ class historicalPricesAPI extends WorkerKV {
         super('historical_price_data', dataSource);
     }
 
-    async getByItemId(requestId, itemId) {
+    async getByItemId(requestId, itemId, limit = 0) {
         await this.init(requestId);
         if (!this.cache) {
             return Promise.reject(new Error('Historical prices cache is empty'));
         }
         if (!this.cache.historicalPricePoint[itemId]) return [];
+        if (limit) {
+            return this.cache.historicalPricePoint[itemId].slice(Math.max(this.cache.historicalPricePoint[itemId].length - limit, 0));
+        }
         return this.cache.historicalPricePoint[itemId];
     }
 }

--- a/index.js
+++ b/index.js
@@ -163,7 +163,6 @@ async function graphqlHandler(event, graphQLOptions) {
 
     const context = { data: dataAPI, util: graphqlUtil, requestId, warnings: [] };
     let result = await graphql(await getSchema(dataAPI, requestId), query, {}, context, variables);
-    console.log(context.warnings)
     if (context.warnings.length > 0) {
         if (!result.warnings) {
             result = Object.assign({warnings: []}, result);

--- a/index.js
+++ b/index.js
@@ -161,12 +161,21 @@ async function graphqlHandler(event, graphQLOptions) {
         //console.log(`Skipping cache in ${ENVIRONMENT} environment`);
     }
 
-    let result = await graphql(await getSchema(dataAPI, requestId), query, {}, { data: dataAPI, util: graphqlUtil, requestId }, variables);
+    const context = { data: dataAPI, util: graphqlUtil, requestId, warnings: [] };
+    let result = await graphql(await getSchema(dataAPI, requestId), query, {}, context, variables);
+    console.log(context.warnings)
+    if (context.warnings.length > 0) {
+        if (!result.warnings) {
+            result = Object.assign({warnings: []}, result);
+        }
+        result.warnings.push(...context.warnings);
+    }
 
     let ttl = dataAPI.getRequestTtl(requestId);
 
     if (specialCache === 'application/json') {
         if (!result.warnings) {
+            'specialCache !result.warnings'
             result = Object.assign({warnings: []}, result);
         }
         ttl = 15 * 60;

--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -192,7 +192,11 @@ module.exports = {
         },
         async historicalPrices(data, args, context, info) {
             context.util.testDepthLimit(info, 1);
-            return context.data.historicalPrice.getByItemId(context.requestId, data.id);
+            const warningMessage = 'Querying historicalPrices on the Item object will return only the 10 most recent prices. For a full list of historical prices, use the historicalItemPrices query.';
+            if (!context.warnings.some(warning => warning.message === warningMessage)) {
+                context.warnings.push({message: warningMessage});
+            }
+            return context.data.historicalPrice.getByItemId(context.requestId, data.id, 10);
         },
         imageLink(data) {
             return data.inspectImageLink;


### PR DESCRIPTION
Currently, if a user queries the historicalPrices field on the Item object, it returns all historical prices. When querying all items, this can be a massive amount of data to transmit. This PR limits the maximum number of prices returned in that context to 10. It also includes a warning telling the user to use the historicalItemPrices query if they want all the prices.
![image](https://user-images.githubusercontent.com/35779878/218262992-6f6c906a-5546-46c0-a3bf-ad9a3e198b2d.png)

One downside of this approach is that it's trivial to programatically create a single historicalItemPrices query request that simultaneously requests the historical prices for all items.