### PR TITLE
New KV retrieval for each request

### DIFF
--- a/datasources/barters.js
+++ b/datasources/barters.js
@@ -13,13 +13,13 @@ class BartersAPI extends WorkerKV {
         super('barter_data', dataSource);
     }
 
-    async getList(requestId) {
-        await this.init(requestId);
+    async getList() {
+        await this.init();
         return this.cache.Barter;
     }
 
-    async getBartersForItem(requestId, id) {
-        await this.init(requestId);
+    async getBartersForItem(id) {
+        await this.init();
         return this.cache.Barter.filter(barter => {
             for (const item of barter.rewardItems) {
                 if (item.item === id) return true;
@@ -29,8 +29,8 @@ class BartersAPI extends WorkerKV {
         });
     }
 
-    async getBartersUsingItem(requestId, id) {
-        await this.init(requestId);
+    async getBartersUsingItem(id) {
+        await this.init();
         return this.cache.Barter.filter(barter => {
             for (const item of barter.requiredItems) {
                 if (item.item === id) return true;
@@ -45,16 +45,16 @@ class BartersAPI extends WorkerKV {
         });
     }
 
-    async getBartersForTrader(requestId, id) {
-        await this.init(requestId);
+    async getBartersForTrader(id) {
+        await this.init();
         return this.cache.Barter.filter(barter => {
             if (barter.trader_id === id) return true;
             return false;
         });
     }
 
-    async getBartersForTraderLevel(requestId, id, level) {
-        await this.init(requestId);
+    async getBartersForTraderLevel(id, level) {
+        await this.init();
         return this.cache.Barter.filter(barter => {
             if (barter.trader_id === id && barter.level === level) return true;
             return false;

--- a/datasources/crafts.js
+++ b/datasources/crafts.js
@@ -6,18 +6,18 @@ class CraftsAPI extends WorkerKV {
         super('craft_data', dataSource);
     }
 
-    async getList(requestId) {
-        await this.init(requestId);
+    async getList() {
+        await this.init();
         return this.cache.Craft;
     }
 
-    async get(requestId, id) {
-        await this.init(requestId);
+    async get(id) {
+        await this.init();
         return this.cache.Craft.filter(c => c.id === id);
     }
 
-    async getCraftsForItem(requestId, id) {
-        await this.init(requestId);
+    async getCraftsForItem(id) {
+        await this.init();
         return this.cache.Craft.filter(craft => {
             for (const item of craft.rewardItems) {
                 if (item.item === id) return true;
@@ -26,8 +26,8 @@ class CraftsAPI extends WorkerKV {
         });
     }
 
-    async getCraftsUsingItem(requestId, id) {
-        await this.init(requestId);
+    async getCraftsUsingItem(id) {
+        await this.init();
         return this.cache.Craft.filter(craft => {
             for (const item of craft.requiredItems) {
                 if (item.item === id) return true;
@@ -36,16 +36,16 @@ class CraftsAPI extends WorkerKV {
         });
     }
 
-    async getCraftsForStation(requestId, id) {
-        await this.init(requestId);
+    async getCraftsForStation(id) {
+        await this.init();
         return this.cache.Craft.filter(craft => {
             if (craft.station_id === id) return true;
             return false;
         });
     }
 
-    async getCraftsForStationLevel(requestId, id, level) {
-        await this.init(requestId);
+    async getCraftsForStationLevel(id, level) {
+        await this.init();
         return this.cache.Craft.filter(craft => {
             if (craft.station_id === id && craft.level === level) return true;
             return false;

--- a/datasources/hideout.js
+++ b/datasources/hideout.js
@@ -5,13 +5,13 @@ class HideoutAPI extends WorkerKV {
         super('hideout_data', dataSource);
     }
 
-    async getList(requestId) {
-        await this.init(requestId);
+    async getList() {
+        await this.init();
         return this.cache.HideoutStation;
     }
 
-    async getModuleById(requestId, id) {
-        await this.init(requestId);
+    async getModuleById(id) {
+        await this.init();
         for (const hideoutStation of this.cache.HideoutStation) {
             for (const stage of hideoutStation.levels) {
                 if (stage.id === id) {
@@ -22,8 +22,8 @@ class HideoutAPI extends WorkerKV {
         return Promise.reject(new Error(`No hideout station level found with id ${id}`));
     }
 
-    async getModuleByLevel(requestId, stationId, level) {
-        await this.init(requestId);
+    async getModuleByLevel(stationId, level) {
+        await this.init();
         for (const hideoutStation of this.cache.HideoutStation) {
             if (hideoutStation.id !== stationId) continue;
             for (const stage of hideoutStation.levels) {
@@ -35,21 +35,21 @@ class HideoutAPI extends WorkerKV {
         return Promise.reject(new Error(`No hideout station level found with id ${stationId} and level ${level}`));
     }
 
-    async getStation(requestId, id) {
-        await this.init(requestId);
+    async getStation(id) {
+        await this.init();
         for (const station of this.cache.HideoutStation) {
             if (station.id === id) return station;
         }
         return Promise.reject(new Error(`No hideout station found with id ${id}`));
     }
 
-    async getLegacyList(requestId) {
-        await this.init(requestId);
+    async getLegacyList() {
+        await this.init();
         return this.cache.HideoutModule;
     }
 
-    async getLegacyModule(requestId, name, level) {
-        await this.init(requestId);
+    async getLegacyModule(name, level) {
+        await this.init();
         for (const module of this.cache.HideoutModule) {
             if (module.name === name && module.quantity === level) {
                 return module;

--- a/datasources/historical-prices.js
+++ b/datasources/historical-prices.js
@@ -5,8 +5,8 @@ class historicalPricesAPI extends WorkerKV {
         super('historical_price_data', dataSource);
     }
 
-    async getByItemId(requestId, itemId, limit = 0) {
-        await this.init(requestId);
+    async getByItemId(itemId, limit = 0) {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Historical prices cache is empty'));
         }

--- a/datasources/items.js
+++ b/datasources/items.js
@@ -65,8 +65,8 @@ class ItemsAPI extends WorkerKV {
         return item;
     }
 
-    async getItem(requestId, id, contains) {
-        await this.init(requestId);
+    async getItem(id, contains) {
+        await this.init();
         let item = this.cache.Item[id];
         if (!item) {
             return Promise.reject(new Error(`No item found with id ${id}`));
@@ -83,15 +83,15 @@ class ItemsAPI extends WorkerKV {
         return formatted;
     }
 
-    async getAllItems(requestId) {
-        await this.init(requestId);
+    async getAllItems() {
+        await this.init();
         return Object.values(this.cache.Item).map((rawItem) => {
             return this.formatItem(rawItem);
         });
     }
 
-    async getItemsByIDs(requestId, ids, items = false) {
-        await this.init(requestId);
+    async getItemsByIDs(ids, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -105,8 +105,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByType(requestId, type, items = false) {
-        await this.init(requestId);
+    async getItemsByType(type, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -120,8 +120,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByTypes(requestId, types, items = false) {
-        await this.init(requestId);
+    async getItemsByTypes(types, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -138,8 +138,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByName(requestId, name, items = false, lang = 'en') {
-        await this.init(requestId);
+    async getItemsByName(name, items = false, lang = 'en') {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -163,8 +163,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByNames(requestId, names, items = false, lang = 'en') {
-        await this.init(requestId);
+    async getItemsByNames(names, items = false, lang = 'en') {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -191,8 +191,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByBsgCategoryId(requestId, bsgCategoryId, items = false) {
-        await this.init(requestId);
+    async getItemsByBsgCategoryId(bsgCategoryId, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -206,8 +206,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByBsgCategoryIds(requestId, bsgCategoryIds, items = false) {
-        await this.init(requestId);
+    async getItemsByBsgCategoryIds(bsgCategoryIds, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -221,8 +221,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByCategoryEnums(requestId, names, items = false) {
-        await this.init(requestId);
+    async getItemsByCategoryEnums(names, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -237,8 +237,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsByHandbookCategoryEnums(requestId, names, items = false) {
-        await this.init(requestId);
+    async getItemsByHandbookCategoryEnums(names, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -253,8 +253,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemsInBsgCategory(requestId, bsgCategoryId, items = false) {
-        await this.init(requestId);
+    async getItemsInBsgCategory(bsgCategoryId, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -268,8 +268,8 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getItemByNormalizedName(requestId, normalizedName) {
-        await this.init(requestId);
+    async getItemByNormalizedName(normalizedName) {
+        await this.init();
         const item = Object.values(this.cache.Item).find((item) => item.normalized_name === normalizedName);
 
         if (!item) {
@@ -279,8 +279,8 @@ class ItemsAPI extends WorkerKV {
         return this.formatItem(item);
     }
 
-    async getItemsByDiscardLimitedStatus(requestId, limited, items = false) {
-        await this.init(requestId);
+    async getItemsByDiscardLimitedStatus(limited, items = false) {
+        await this.init();
         let format = false;
         if (!items) {
             items = Object.values(this.cache.Item);
@@ -294,20 +294,20 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getCategory(requestId, id) {
-        await this.init(requestId);
+    async getCategory(id) {
+        await this.init();
         return this.cache.ItemCategory[id] || this.cache.HandbookCategory[id];
     }
 
-    async getTopCategory(requestId, id) {
-        await this.init(requestId);
+    async getTopCategory(id) {
+        await this.init();
         const cat = await this.getCategory(id);
         if (cat && cat.parent_id) return this.getTopCategory(cat.parent_id);
         return cat;
     }
 
-    async getCategories(requestId) {
-        await this.init(requestId);
+    async getCategories() {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Item cache is empty'));
         }
@@ -318,8 +318,8 @@ class ItemsAPI extends WorkerKV {
         return categories;
     }
 
-    async getCategoriesEnum(requestId) {
-        const cats = await this.getCategories(requestId);
+    async getCategoriesEnum() {
+        const cats = await this.getCategories();
         const map = {};
         for (const id in cats) {
             map[cats[id].enumName] = cats[id];
@@ -327,36 +327,36 @@ class ItemsAPI extends WorkerKV {
         return map;
     }
 
-    async getHandbookCategory(requestId, id) {
-        await this.init(requestId);
+    async getHandbookCategory(id) {
+        await this.init();
         return this.cache.HandbookCategory[id];
     }
 
-    async getHandbookCategories(requestId) {
-        await this.init(requestId);
+    async getHandbookCategories() {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Item cache is empty'));
         }
         return Object.values(this.cache.HandbookCategory);
     }
 
-    async getFleaMarket(requestId) {
-        await this.init(requestId);
+    async getFleaMarket() {
+        await this.init();
         return this.cache.FleaMarket;
     }
 
-    async getArmorMaterials(requestId) {
-        await this.init(requestId);
+    async getArmorMaterials() {
+        await this.init();
         return Object.values(this.cache.ArmorMaterial).sort();
     }
 
-    async getArmorMaterial(requestId, matKey) {
-        await this.init(requestId);
+    async getArmorMaterial(matKey) {
+        await this.init();
         return this.cache.ArmorMaterial[matKey];
     }
 
-    async getAmmoList(requestId) {
-        const allAmmo = await this.getItemsByBsgCategoryId(requestId, '5485a8684bdc2da71d8b4567').then(ammoItems => {
+    async getAmmoList() {
+        const allAmmo = await this.getItemsByBsgCategoryId('5485a8684bdc2da71d8b4567').then(ammoItems => {
             // ignore bb
             return ammoItems.filter(item => item.id !== '6241c316234b593b5676b637');
         });
@@ -368,18 +368,18 @@ class ItemsAPI extends WorkerKV {
         });
     }
 
-    async getPlayerLevels(requestId) {
-        await this.init(requestId);
+    async getPlayerLevels() {
+        await this.init();
         return this.cache.PlayerLevel;
     }
 
-    async getTypes(requestId) {
-        await this.init(requestId);
+    async getTypes() {
+        await this.init();
         return this.cache.ItemType;
     }
 
-    async getLanguageCodes(requestId) {
-        await this.init(requestId);
+    async getLanguageCodes() {
+        await this.init();
         return this.cache.LanguageCode;
     }
 }

--- a/datasources/maps.js
+++ b/datasources/maps.js
@@ -5,21 +5,21 @@ class MapAPI extends WorkerKV {
         super('map_data', dataSource);
     }
 
-    async getList(requestId) {
-        await this.init(requestId);
+    async getList() {
+        await this.init();
         return this.cache.Map;
     }
 
-    async get(requestId, id) {
-        await this.init(requestId);
+    async get(id) {
+        await this.init();
         for (const map of this.cache.Map) {
             if (map.id === id || map.tarkovDataId === id) return map;
         }
         return Promise.reject(new Error(`No map found with id ${id}`));
     }
 
-    async getMapsByNames(requestId, names, maps = false, lang = 'en') {
-        await this.init(requestId);
+    async getMapsByNames(names, maps = false, lang = 'en') {
+        await this.init();
         if (!maps) {
             maps = this.cache.Map;
         }
@@ -39,8 +39,8 @@ class MapAPI extends WorkerKV {
         });
     }
 
-    async getMapsByEnemies(requestId, enemies, maps = false, lang = 'en') {
-        await this.init(requestId);
+    async getMapsByEnemies(enemies, maps = false, lang = 'en') {
+        await this.init();
         if (!maps) {
             maps = this.cache.Map;
         }
@@ -60,18 +60,18 @@ class MapAPI extends WorkerKV {
         });
     }
 
-    async getAllBosses(requestId) {
-        await this.init(requestId);
+    async getAllBosses() {
+        await this.init();
         return Object.values(this.cache.MobInfo);
     }
 
-    async getMobInfo(requestId, mobId) {
-        await this.init(requestId);
+    async getMobInfo(mobId) {
+        await this.init();
         return this.cache.MobInfo[mobId];
     }
 
-    async getBossesByNames(requestId, names, bosses = false, lang = 'en') {
-        await this.init(requestId);
+    async getBossesByNames(names, bosses = false, lang = 'en') {
+        await this.init();
         if (!bosses) {
             bosses = Object.values(this.cache.MobInfo);
         }

--- a/datasources/schema.js
+++ b/datasources/schema.js
@@ -5,32 +5,32 @@ class SchemaAPI extends WorkerKV {
         super('schema_data', dataSource);
     }
 
-    async getCategories(requestId) {
-        await this.init(requestId);
+    async getCategories() {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Schema cache is empty'));
         }
         return this.cache.ItemCategory;
     }
 
-    async getHandbookCategories(requestId) {
-        await this.init(requestId);
+    async getHandbookCategories() {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Schema cache is empty'));
         }
         return this.cache.HandbookCategory;
     }
 
-    async getItemTypes(requestId) {
-        await this.init(requestId);
+    async getItemTypes() {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Schema cache is empty'));
         }
         return this.cache.ItemType;
     }
 
-    async getLanguageCodes(requestId) {
-        await this.init(requestId);
+    async getLanguageCodes() {
+        await this.init();
         if (!this.cache) {
             return Promise.reject(new Error('Schema cache is empty'));
         }

--- a/datasources/tasks.js
+++ b/datasources/tasks.js
@@ -5,21 +5,21 @@ class TasksAPI extends WorkerKV {
         super('quest_data', dataSource);
     }
 
-    async getList(requestId) {
-        await this.init(requestId);
+    async getList() {
+        await this.init();
         return this.cache.Task;
     }
 
-    async get(requestId, id) {
-        await this.init(requestId);
+    async get(id) {
+        await this.init();
         for (const task of this.cache.Task) {
             if (task.id === id || task.tarkovDataId === id) return task;
         }
         return Promise.reject(new Error(`No task found with id ${id}`));
     }
 
-    async getTasksRequiringItem(requestId, itemId) {
-        await this.init(requestId);
+    async getTasksRequiringItem(itemId) {
+        await this.init();
         const tasks = this.cache.Task.filter(rawTask => {
             for (const obj of rawTask.objectives) {
                 if (obj.item === itemId) {
@@ -75,8 +75,8 @@ class TasksAPI extends WorkerKV {
         });
     }
 
-    async getTasksProvidingItem(requestId, itemId) {
-        await this.init(requestId);
+    async getTasksProvidingItem(itemId) {
+        await this.init();
         const tasks = this.cache.Task.filter(rawTask => {
             for (const reward of rawTask.startRewards.items) {
                 if (reward.item === itemId) {
@@ -105,14 +105,14 @@ class TasksAPI extends WorkerKV {
         });
     }
 
-    async getQuests(requestId) {
-        await this.init(requestId);
+    async getQuests() {
+        await this.init();
         return this.cache.Quest;
     }
 
-    async getQuest(requestId, id) {
-        await this.init(requestId);
-        const quests = await this.getQuests(requestId);
+    async getQuest(id) {
+        await this.init();
+        const quests = await this.getQuests();
         for (const quest of quests) {
             if (quest.id === id) {
                 return quest;
@@ -121,13 +121,13 @@ class TasksAPI extends WorkerKV {
         return Promise.reject(new Error(`No quest with id ${id} found`));
     }
 
-    async getQuestItems(requestId) {
-        await this.init(requestId);
+    async getQuestItems() {
+        await this.init();
         return Object.values(this.cache.QuestItem);
     }
 
-    async getQuestItem(requestId, id) {
-        await this.init(requestId);
+    async getQuestItem(id) {
+        await this.init();
         return this.cache.QuestItem[id];
     }
 }

--- a/datasources/trader-inventory.js
+++ b/datasources/trader-inventory.js
@@ -6,8 +6,8 @@ class TraderInventoryAPI extends WorkerKV {
         this.traderCache = false;
     }
 
-    async initTraderCache(requestId) {
-        await this.init(requestId);
+    async initTraderCache() {
+        await this.init();
         if (this.traderCache) {
             return true;
         }
@@ -26,22 +26,22 @@ class TraderInventoryAPI extends WorkerKV {
         }
     }
 
-    async getByItemId(requestId, itemId) {
-        await this.init(requestId);
+    async getByItemId(itemId) {
+        await this.init();
         if (!this.cache.TraderCashOffer[itemId]) {
             return [];
         }
         return this.cache.TraderCashOffer[itemId];
     }
 
-    async getPricesForTrader(requestId, traderId) {
-        await this.initTraderCache(requestId);
+    async getPricesForTrader(traderId) {
+        await this.initTraderCache();
         if (!this.traderCache[traderId]) return [];
         return this.traderCache[traderId];
     }
 
-    async getPricesForTraderLevel(requestId, traderId, level) {
-        await this.initTraderCache(requestId);
+    async getPricesForTraderLevel(traderId, level) {
+        await this.initTraderCache();
         if (!this.traderCache[traderId]) return [];
         return this.traderCache[traderId].filter(offer => {
             return offer.vendor.traderLevel === level;

--- a/datasources/traders.js
+++ b/datasources/traders.js
@@ -41,13 +41,13 @@ class TradersAPI extends WorkerKV {
         super('trader_data', dataSource);
     }
 
-    async getList(requestId) {
-        await this.init(requestId);
+    async getList() {
+        await this.init();
         return this.cache.Trader;
     }
 
-    async get(requestId, id) {
-        await this.init(requestId);
+    async get(id) {
+        await this.init();
         for (const trader of this.cache.Trader) {
             if (trader.id === id) {
                 return trader;
@@ -57,8 +57,8 @@ class TradersAPI extends WorkerKV {
         return Promise.reject(new Error(`No trader found with id ${id}`));
     }
 
-    async getByName(requestId, name) {
-        await this.init(requestId);
+    async getByName(name) {
+        await this.init();
         for (const trader of this.cache.Trader) {
             if (trader.name.toLowerCase() === name.toLowerCase()) {
                 return trader;
@@ -68,8 +68,8 @@ class TradersAPI extends WorkerKV {
         return Promise.reject(new Error(`No trader found with name ${name}`));
     }
 
-    async getByLevel(requestId, traderId, level) {
-        await this.init(requestId);
+    async getByLevel(traderId, level) {
+        await this.init();
         for (const trader of this.cache.Trader) {
             if (trader.id !== traderId) continue;
             for (const rawLevel of trader.levels) {
@@ -81,12 +81,12 @@ class TradersAPI extends WorkerKV {
         return Promise.reject(new Error(`No trader found with id ${traderId} and level ${level}`));
     }
 
-    getByDataId(requestId, dataId) {
-        return this.get(requestId, dataIdMap[dataId]);
+    getByDataId(dataId) {
+        return this.get(dataIdMap[dataId]);
     }
 
-    async getTraderResets(requestId) {
-        await this.init(requestId);
+    async getTraderResets() {
+        await this.init();
         return this.cache.Trader.map(trader => {
             return {
                 name: trader.name.toLowerCase(),

--- a/resolvers/ammoResolver.js
+++ b/resolvers/ammoResolver.js
@@ -1,12 +1,12 @@
 module.exports = {
     Query: {
         ammo(obj, args, context, info) {
-            return context.util.paginate(context.data.item.getAmmoList(context.requestId), args);
+            return context.util.paginate(context.data.item.getAmmoList(), args);
         }
     },
     Ammo: {
         item(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.id);
+            return context.data.item.getItem(data.id);
         }
     }
 };

--- a/resolvers/barterResolver.js
+++ b/resolvers/barterResolver.js
@@ -1,16 +1,16 @@
 module.exports = {
     Query: {
         barters(obj, args, context, info) {
-            return context.util.paginate(context.data.barter.getList(context.requestId), args);
+            return context.util.paginate(context.data.barter.getList(), args);
         }
     },
     Barter: {
         taskUnlock(data, args, context) {
             if (!data || !data.taskUnlock) return null;
-            return context.data.task.get(context.requestId, data.taskUnlock);
+            return context.data.task.get(data.taskUnlock);
         },
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id);
+            return context.data.trader.get(data.trader_id);
         }
     }
 };

--- a/resolvers/craftResolver.js
+++ b/resolvers/craftResolver.js
@@ -1,7 +1,7 @@
 module.exports = {
     Query: {
         crafts(obj, args, context, info) {
-            return context.util.paginate(context.data.craft.getList(context.requestId), args);
+            return context.util.paginate(context.data.craft.getList(), args);
         }
     },
     Craft: {
@@ -10,15 +10,15 @@ module.exports = {
                 if (qi === null) {
                     return qi;
                 }
-                return context.data.task.getQuestItem(context.requestId, qi.item);
+                return context.data.task.getQuestItem(qi.item);
             }));
         },
         station(data, args, context) {
-            return context.data.hideout.getStation(context.requestId, data.station);
+            return context.data.hideout.getStation(data.station);
         },
         taskUnlock(data, args, context) {
             if (!data || !data.taskUnlock) return null;
-            return context.data.task.get(context.requestId, data.taskUnlock);
+            return context.data.task.get(data.taskUnlock);
         },
     }
 };

--- a/resolvers/hideoutResolver.js
+++ b/resolvers/hideoutResolver.js
@@ -1,16 +1,16 @@
 module.exports = {
     Query: {
         hideoutModules(obj, args, context, info) {
-            return context.data.hideout.getLegacyList(context.requestId);
+            return context.data.hideout.getLegacyList();
         },
         hideoutStations(obj, args, context, info) {
-            return context.util.paginate(context.data.hideout.getList(context.requestId), args);
+            return context.util.paginate(context.data.hideout.getList(), args);
         },
     },
     HideoutStation: {
         crafts(data, args, context, info) {
             context.util.testDepthLimit(info, 1);
-            return context.data.craft.getCraftsForStation(context.requestId, data.id);
+            return context.data.craft.getCraftsForStation(data.id);
         },
         name(data, args, context, info) {
             return context.util.getLocale(data, 'name', info);
@@ -27,13 +27,13 @@ module.exports = {
             if (!data.slotItems || data.slotItems.length === 0) {
                 return [];
             }
-            return context.data.item.getItemsByIDs(context.requestId, data.slotItems);
+            return context.data.item.getItemsByIDs(data.slotItems);
         }
     },
     HideoutStationLevel: {
         crafts(data, args, context, info) {
             context.util.testDepthLimit(info, 2);
-            return context.data.craft.getCraftsForStationLevel(context.requestId, data.id.substring(0, data.id.indexOf('-')), data.level);
+            return context.data.craft.getCraftsForStationLevel(data.id.substring(0, data.id.indexOf('-')), data.level);
         },
         description(data, args, context, info) {
             return context.util.getLocale(data, 'description', info);
@@ -41,13 +41,13 @@ module.exports = {
     },
     RequirementHideoutStationLevel: {
         station(data, args, context) {
-            return context.data.hideout.getStation(context.requestId, data.station);
+            return context.data.hideout.getStation(data.station);
         }
     },
     HideoutModule: {
         moduleRequirements(data, args, context) {
             return data.moduleRequirements.map(req => {
-                return context.data.hideout.getLegacyModule(context.requestId, req.name, req.quantity);
+                return context.data.hideout.getLegacyModule(req.name, req.quantity);
             });
         }
     }

--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -1,7 +1,7 @@
 module.exports = {
     Query: {
         item(obj, args, context, info) {
-            if (args.id) return context.data.item.getItem(context.requestId, args.id);
+            if (args.id) return context.data.item.getItem(args.id);
             if (args.normalizedName) return context.data.item.getItemByNormalizedName(args.normalizedName);
             return Promise.reject(new Error('You must specify either the id or the normalizedName argument'));
         },
@@ -10,34 +10,34 @@ module.exports = {
             const lang = context.util.getLang(info);
             let filters = {
                 ids: async ids => {
-                    return context.data.item.getItemsByIDs(context.requestId, ids, items);
+                    return context.data.item.getItemsByIDs(ids, items);
                 },
                 name: async name => {
-                    return context.data.item.getItemsByName(context.requestId, name, items, lang);
+                    return context.data.item.getItemsByName(name, items, lang);
                 },
                 names: async names => {
-                    return context.data.item.getItemsByNames(context.requestId, names, items, lang);
+                    return context.data.item.getItemsByNames(names, items, lang);
                 },
                 type: async type => {
-                    return context.data.item.getItemsByType(context.requestId, type, items);
+                    return context.data.item.getItemsByType(type, items);
                 },
                 types: async types => {
-                    return context.data.item.getItemsByTypes(context.requestId, types, items);
+                    return context.data.item.getItemsByTypes(types, items);
                 },
                 categoryNames: async bsgcats => {
-                    return context.data.item.getItemsByCategoryEnums(context.requestId, bsgcats, items);
+                    return context.data.item.getItemsByCategoryEnums(bsgcats, items);
                 },
                 handbookCategoryNames: async handbookcats => {
-                    return context.data.item.getItemsByHandbookCategoryEnums(context.requestId, handbookcats, items);
+                    return context.data.item.getItemsByHandbookCategoryEnums(handbookcats, items);
                 },
                 bsgCategoryId: async bsgcat => {
-                    return context.data.item.getItemsByBsgCategoryId(context.requestId, bsgcat, items);
+                    return context.data.item.getItemsByBsgCategoryId(bsgcat, items);
                 },
                 bsgCategoryIds: async bsgcats => {
-                    return context.data.item.getItemsByBsgCategoryIds(context.requestId, bsgcats, items);
+                    return context.data.item.getItemsByBsgCategoryIds(bsgcats, items);
                 },
                 bsgCategory: async bsgcat => {
-                    return context.data.item.getItemsInBsgCategory(context.requestId, bsgcat, items);
+                    return context.data.item.getItemsInBsgCategory(bsgcat, items);
                 },
                 /*discardLimited: async limited => {
                     return context.data.item.getItemsByDiscardLimitedStatus(limited, items);
@@ -51,42 +51,42 @@ module.exports = {
                 items = await filters[argName](args[argName], items);
             }
             if (!items) {
-                items = context.data.item.getAllItems(context.requestId);
+                items = context.data.item.getAllItems();
             }
             return context.util.paginate(items, args);
         },
         itemCategories(obj, args, context) {
-            return context.util.paginate(context.data.item.getCategories(context.requestId), args);
+            return context.util.paginate(context.data.item.getCategories(), args);
         },
         handbookCategories(obj, args, context) {
-            return context.util.paginate(context.data.item.getHandbookCategories(context.requestId), args);
+            return context.util.paginate(context.data.item.getHandbookCategories(), args);
         },
         itemsByIDs(obj, args, context, info) {
-            return context.data.item.getItemsByIDs(context.requestId, args.ids, false);
+            return context.data.item.getItemsByIDs(args.ids, false);
         },
         itemsByType(obj, args, context, info) {
-            return context.data.item.getItemsByType(context.requestId, args.type, false);
+            return context.data.item.getItemsByType(args.type, false);
         },
         itemsByName(obj, args, context, info) {
-            return context.data.item.getItemsByName(context.requestId, args.name, false, undefined);
+            return context.data.item.getItemsByName(args.name, false, undefined);
         },
         itemByNormalizedName(obj, args, context, info) {
-            return context.data.item.getItemByNormalizedName(context.requestId, args.normalizedName);
+            return context.data.item.getItemByNormalizedName(args.normalizedName);
         },
         itemsByBsgCategoryId(obj, args, context, info) {
-            return context.data.item.getItemsByBsgCategoryId(context.requestId, args.bsgCategoryId, undefined);
+            return context.data.item.getItemsByBsgCategoryId(args.bsgCategoryId, undefined);
         },
         historicalItemPrices(obj, args, context, info) {
-            return context.util.paginate(context.data.historicalPrice.getByItemId(context.requestId, args.id), args);
+            return context.util.paginate(context.data.historicalPrice.getByItemId(args.id), args);
         },
         armorMaterials(obj, args, context) {
-            return context.data.item.getArmorMaterials(context.requestId);
+            return context.data.item.getArmorMaterials();
         },
         fleaMarket(obj, args, context) {
-            return context.data.item.getFleaMarket(context.requestId);
+            return context.data.item.getFleaMarket();
         },
         playerLevels(obj, args, context) {
-            return context.data.item.getPlayerLevels(context.requestId);
+            return context.data.item.getPlayerLevels();
         }
     },
     Item: {
@@ -102,35 +102,35 @@ module.exports = {
         async buyFor(data, args, context) {
             if (!data.buyFor) data.buyFor = [];
             return [
-                ...await context.data.traderInventory.getByItemId(context.requestId, data.id),
+                ...await context.data.traderInventory.getByItemId(data.id),
                 ...data.buyFor
             ];
         },
         bsgCategory(data, args, context) {
-            if (data.bsgCategoryId) return context.data.item.getCategory(context.requestId, data.bsgCategoryId);
+            if (data.bsgCategoryId) return context.data.item.getCategory(data.bsgCategoryId);
             return null;
         },
         category(data, args, context) {
-            if (data.bsgCategoryId) return context.data.item.getCategory(context.requestId, data.bsgCategoryId);
+            if (data.bsgCategoryId) return context.data.item.getCategory(data.bsgCategoryId);
             return null;
         },
         categoryTop(data, args, context) {
-            if (data.bsgCategoryId) return context.data.item.getTopCategory(context.requestId, data.bsgCategoryId);
+            if (data.bsgCategoryId) return context.data.item.getTopCategory(data.bsgCategoryId);
             return null;
         },
         categories(data, args, context) {
             return data.categories.map(id => {
-                return context.data.item.getCategory(context.requestId, id);
+                return context.data.item.getCategory(id);
             });
         },
         handbookCategories(data, args, context) {
             return data.handbookCategories.map(id => {
-                return context.data.item.getCategory(context.requestId, id);
+                return context.data.item.getCategory(id);
             });
         },
         async conflictingItems(data, args, context) {
             return Promise.all(data.conflictingItems.map(async id => {
-                const item = await context.data.item.getItem(context.requestId, id).catch(error => {
+                const item = await context.data.item.getItem(id).catch(error => {
                     console.warn(`item ${id} not found for conflictingItems`);
                     return null;
                 });
@@ -139,22 +139,22 @@ module.exports = {
             }));
         },
         usedInTasks(data, args, context) {
-            return context.data.task.getTasksRequiringItem(context.requestId, data.id);
+            return context.data.task.getTasksRequiringItem(data.id);
         },
         receivedFromTasks(data, args, context) {
-            return context.data.task.getTasksProvidingItem(context.requestId, data.id);
+            return context.data.task.getTasksProvidingItem(data.id);
         },
         bartersFor(data, args, context) {
-            return context.data.barter.getBartersForItem(context.requestId, data.id);
+            return context.data.barter.getBartersForItem(data.id);
         },
         bartersUsing(data, args, context) {
-            return context.data.barter.getBartersUsingItem(context.requestId, data.id);
+            return context.data.barter.getBartersUsingItem(data.id);
         },
         craftsFor(data, args, context) {
-            return context.data.craft.getCraftsForItem(context.requestId, data.id);
+            return context.data.craft.getCraftsForItem(data.id);
         },
         craftsUsing(data, args, context) {
-            return context.data.craft.getCraftsUsingItem(context.requestId, data.id);
+            return context.data.craft.getCraftsUsingItem(data.id);
         },
         async fleaMarketFee(data, args, context) {
             if (data.types.includes('noFlea')) return null;
@@ -166,7 +166,7 @@ module.exports = {
                 requireAll: false,
                 ...args
             };
-            const flea = await context.data.item.getFleaMarket(context.requestId);
+            const flea = await context.data.item.getFleaMarket();
             const q = options.requireAll ? 1 : options.count;
             const vo = data.basePrice * (options.count / q);
             const vr = options.price;
@@ -196,7 +196,7 @@ module.exports = {
             if (!context.warnings.some(warning => warning.message === warningMessage)) {
                 context.warnings.push({message: warningMessage});
             }
-            return context.data.historicalPrice.getByItemId(context.requestId, data.id, 10);
+            return context.data.historicalPrice.getByItemId(data.id, 10);
         },
         imageLink(data) {
             return data.inspectImageLink;
@@ -226,30 +226,30 @@ module.exports = {
             return context.util.getLocale(data, 'name', info);
         },
         parent(data, args, context) {
-            if (data.parent_id) return context.data.item.getCategory(context.requestId, data.parent_id);
+            if (data.parent_id) return context.data.item.getCategory(data.parent_id);
             return null;
         },
         children(data, args, context) {
-            return data.child_ids.map(id => context.data.item.getCategory(context.requestId, id));
+            return data.child_ids.map(id => context.data.item.getCategory(id));
         }
     },
     ItemFilters: {
         allowedCategories(data, args, context) {
-            return data.allowedCategories.map(id => context.data.item.getCategory(context.requestId, id));
+            return data.allowedCategories.map(id => context.data.item.getCategory(id));
         },
         allowedItems(data, args, context) {
-            return data.allowedItems.map(id => context.data.item.getItem(context.requestId, id));
+            return data.allowedItems.map(id => context.data.item.getItem(id));
         },
         excludedCategories(data, args, context) {
-            return data.excludedCategories.map(id => context.data.item.getCategory(context.requestId, id));
+            return data.excludedCategories.map(id => context.data.item.getCategory(id));
         },
         excludedItems(data, args, context) {
-            return data.excludedItems.map(id => context.data.item.getItem(context.requestId, id));
+            return data.excludedItems.map(id => context.data.item.getItem(id));
         },
     },
     ItemPrice: {
         currencyItem(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.currencyItem);
+            return context.data.item.getItem(data.currencyItem);
         }
     },
     ItemProperties: {
@@ -263,7 +263,7 @@ module.exports = {
             return context.util.getLocale(data, 'armorType', info);
         },
         material(data, args, context) {
-            return context.data.item.getArmorMaterial(context.requestId, data.armor_material_id);
+            return context.data.item.getArmorMaterial(data.armor_material_id);
         },
         zones(data, args, context, info) {
             return context.util.getLocale(data, 'zones', info);
@@ -271,7 +271,7 @@ module.exports = {
     },
     ItemPropertiesArmorAttachment: {
         material(data, args, context) {
-            return context.data.item.getArmorMaterial(context.requestId, data.armor_material_id);
+            return context.data.item.getArmorMaterial(data.armor_material_id);
         },
         headZones(data, args, context, info) {
             return context.util.getLocale(data, 'headZones', info);
@@ -287,7 +287,7 @@ module.exports = {
             return context.util.getLocale(data, 'armorType', info);
         },
         material(data, args, context) {
-            return context.data.item.getArmorMaterial(context.requestId, data.armor_material_id);
+            return context.data.item.getArmorMaterial(data.armor_material_id);
         },
         zones(data, args, context, info) {
             return context.util.getLocale(data, 'zones', info);
@@ -298,7 +298,7 @@ module.exports = {
     },
     ItemPropertiesGlasses: {
         material(data, args, context) {
-            return context.data.item.getArmorMaterial(context.requestId, data.armor_material_id);
+            return context.data.item.getArmorMaterial(data.armor_material_id);
         },
     },
     ItemPropertiesHelmet: {
@@ -306,7 +306,7 @@ module.exports = {
             return context.util.getLocale(data, 'armorType', info);
         },
         material(data, args, context) {
-            return context.data.item.getArmorMaterial(context.requestId, data.armor_material_id);
+            return context.data.item.getArmorMaterial(data.armor_material_id);
         },
         headZones(data, args, context, info) {
             return context.util.getLocale(data, 'headZones', info);
@@ -314,31 +314,31 @@ module.exports = {
     },
     ItemPropertiesMagazine: {
         allowedAmmo(data, args, context) {
-            return data.allowedAmmo.map(id => context.data.item.getItem(context.requestId, id));
+            return data.allowedAmmo.map(id => context.data.item.getItem(id));
         }
     },
     ItemPropertiesPreset: {
         baseItem(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.base_item_id);
+            return context.data.item.getItem(data.base_item_id);
         }
     },
     ItemPropertiesWeapon: {
         defaultAmmo(data, args, context) {
             if (!data.default_ammo_id) return null;
-            return context.data.item.getItem(context.requestId, data.default_ammo_id);
+            return context.data.item.getItem(data.default_ammo_id);
         },
         fireModes(data, args, context, info) {
             return context.util.getLocale(data, 'fireModes', info);
         },
         allowedAmmo(data, args, context) {
-            return data.allowedAmmo.map(id => context.data.item.getItem(context.requestId, id));
+            return data.allowedAmmo.map(id => context.data.item.getItem(id));
         },
         defaultPreset(data, args, context) {
             if (!data.defaultPreset) return null;
-            return context.data.item.getItem(context.requestId, data.defaultPreset);
+            return context.data.item.getItem(data.defaultPreset);
         },
         presets(data, args, context) {
-            return Promise.all(data.presets.map(id => context.data.item.getItem(context.requestId, id)));
+            return Promise.all(data.presets.map(id => context.data.item.getItem(id)));
         }
     },
     ItemSlot: {
@@ -348,8 +348,8 @@ module.exports = {
     },
     ContainedItem: {
         item(data, args, context) {
-            if (data.contains) return context.data.item.getItem(context.requestId, data.item, data.contains);
-            return context.data.item.getItem(context.requestId, data.item);
+            if (data.contains) return context.data.item.getItem(data.item, data.contains);
+            return context.data.item.getItem(data.item);
         },
         quantity(data, args, context) {
             return data.count;
@@ -367,7 +367,7 @@ module.exports = {
     },
     RequirementItem: {
         item(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.item);
+            return context.data.item.getItem(data.item);
         },
         quantity(data) {
             return data.count;

--- a/resolvers/mapResolver.js
+++ b/resolvers/mapResolver.js
@@ -5,7 +5,7 @@ module.exports = {
             const lang = context.util.getLang(info);
             let filters = {
                 name: async names => {
-                    return context.data.map.getBossesByNames(context.requestId, names, bosses, lang);
+                    return context.data.map.getBossesByNames(names, bosses, lang);
                 },
             }
             const nonFilterArgs = ['lang', 'limit', 'offset'];
@@ -15,7 +15,7 @@ module.exports = {
                 bosses = await filters[argName](args[argName], bosses);
             }
             if (!bosses) {
-                bosses = context.data.map.getAllBosses(context.requestId);
+                bosses = context.data.map.getAllBosses();
             }
             return context.util.paginate(bosses, args);
         },
@@ -24,10 +24,10 @@ module.exports = {
             const lang = context.util.getLang(info);
             let filters = {
                 name: async names => {
-                    return context.data.map.getMapsByNames(context.requestId, names, maps, lang);
+                    return context.data.map.getMapsByNames(names, maps, lang);
                 },
                 enemies: async enemies => {
-                    return context.data.map.getMapsByEnemies(context.requestId, enemies, maps, lang);
+                    return context.data.map.getMapsByEnemies(enemies, maps, lang);
                 },
             }
             const nonFilterArgs = ['lang', 'limit', 'offset'];
@@ -37,7 +37,7 @@ module.exports = {
                 maps = await filters[argName](args[argName], maps);
             }
             if (!maps) {
-                maps = context.data.map.getList(context.requestId);
+                maps = context.data.map.getList();
             }
             return context.util.paginate(maps, args);
         }
@@ -65,14 +65,14 @@ module.exports = {
     },
     BossSpawn: {
         boss(data, args, context, info) {
-            return context.data.map.getMobInfo(context.requestId, data.id);
+            return context.data.map.getMobInfo(data.id);
         },
         async name(data, args, context, info) {
-            const boss = await context.data.map.getMobInfo(context.requestId, data.id);
+            const boss = await context.data.map.getMobInfo(data.id);
             return context.util.getLocale(boss, 'name', info);
         },
         async normalizedName(data, args, context, info) {
-            const boss = await context.data.map.getMobInfo(context.requestId, data.id);
+            const boss = await context.data.map.getMobInfo(data.id);
             return boss.normalizedName;
         },
         async spawnTrigger(data, args, context, info) {
@@ -86,14 +86,14 @@ module.exports = {
     },
     BossEscort: {
         boss(data, args, context, info) {
-            return context.data.map.getMobInfo(context.requestId, data.id);
+            return context.data.map.getMobInfo(data.id);
         },
         async name(data, args, context, info) {
-            const boss = await context.data.map.getMobInfo(context.requestId, data.id);
+            const boss = await context.data.map.getMobInfo(data.id);
             return context.util.getLocale(boss, 'name', info);
         },
         async normalizedName(data, args, context, info) {
-            const boss = await context.data.map.getMobInfo(context.requestId, data.id);
+            const boss = await context.data.map.getMobInfo(data.id);
             return boss.normalizedName;
         }
     }

--- a/resolvers/taskResolver.js
+++ b/resolvers/taskResolver.js
@@ -1,7 +1,7 @@
 module.exports = {
     Query: {
         async tasks(obj, args, context, info) {
-            const tasks = await context.data.task.getList(context.requestId);
+            const tasks = await context.data.task.getList();
             if (args.faction) {
                 const filterFaction = args.faction.toLowerCase();
                 return tasks.filter(task => {
@@ -13,13 +13,13 @@ module.exports = {
             return context.util.paginate(tasks, args);
         },
         task(obj, args, context) {
-            return context.data.task.get(context.requestId, args.id);
+            return context.data.task.get(args.id);
         },
         quests(obj, args, context, info) {
-            return context.data.task.getQuests(context.requestId);
+            return context.data.task.getQuests();
         },
         questItems(obj, args, context) {
-            return context.data.task.getQuestItems(context.requestId);
+            return context.data.task.getQuestItems();
         }
     },
     HealthEffect: {
@@ -41,21 +41,21 @@ module.exports = {
             return context.util.getLocale(data, 'name', info);
         },
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader);
+            return context.data.trader.get(data.trader);
         },
         map(data, args, context) {
-            if (data.location_id) return context.data.map.get(context.requestId, data.location_id);
+            if (data.location_id) return context.data.map.get(data.location_id);
             return null;
         }
     },
     TaskKey: {
         keys(data, args, context) {
             return data.key_ids.map(id => {
-                return context.data.item.getItem(context.requestId, id);
+                return context.data.item.getItem(id);
             });
         },
         map(data, args, context) {
-            return context.data.map.get(context.requestId, data.map_id);
+            return context.data.map.get(data.map_id);
         }
     },
     TaskObjective: {
@@ -92,14 +92,14 @@ module.exports = {
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         }
     },
     TaskObjectiveBasic: {
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -108,26 +108,26 @@ module.exports = {
     },
     TaskObjectiveBuildItem: {
         item(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.item);
+            return context.data.item.getItem(data.item);
         },
         containsAll(data, args, context) {
             return data.containsAll.map((item) => {
-                return context.data.item.getItem(context.requestId, item.id);
+                return context.data.item.getItem(item.id);
             });
         },
         containsCategory(data, args,context) {
             return data.containsCategory.map((cat) => {
-                return context.data.item.getCategory(context.requestId, cat.id);
+                return context.data.item.getCategory(cat.id);
             });
         },
         containsOne(data, args, context) {
             return data.containsOne.map((item) => {
-                return context.data.item.getItem(context.requestId, item.id);
+                return context.data.item.getItem(item.id);
             });
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -137,7 +137,7 @@ module.exports = {
     TaskObjectiveExperience: {
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -147,7 +147,7 @@ module.exports = {
     TaskObjectiveExtract: {
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -168,11 +168,11 @@ module.exports = {
     },
     TaskObjectiveItem: {
         item(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.item);
+            return context.data.item.getItem(data.item);
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -181,11 +181,11 @@ module.exports = {
     },
     TaskObjectiveMark: {
         markerItem(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.item_id);
+            return context.data.item.getItem(data.item_id);
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -195,7 +195,7 @@ module.exports = {
     TaskObjectivePlayerLevel: {
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -204,11 +204,11 @@ module.exports = {
     },
     TaskObjectiveQuestItem: {
         async questItem(data, args, context) {
-            return context.data.task.getQuestItem(context.requestId, data.item_id);
+            return context.data.task.getQuestItem(data.item_id);
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -218,7 +218,7 @@ module.exports = {
     TaskObjectiveSkill: {
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -235,31 +235,31 @@ module.exports = {
         },
         usingWeapon(data, args, context) {
             return data.usingWeapon.map(item => {
-                return context.data.item.getItem(context.requestId, item.id);
+                return context.data.item.getItem(item.id);
             });
         },
         usingWeaponMods(data, args, context) {
             return data.usingWeaponMods.map(itemGroup => {
                 return itemGroup.map(item => {
-                    return context.data.item.getItem(context.requestId, item.id);
+                    return context.data.item.getItem(item.id);
                 });
             });
         },
         wearing(data, args, context) {
             return data.wearing.map(itemGroup => {
                 return itemGroup.map(item => {
-                    return context.data.item.getItem(context.requestId, item.id);
+                    return context.data.item.getItem(item.id);
                 });
             });
         },
         notWearing(data, args, context) {
             return data.notWearing.map((item) => {
-                return context.data.item.getItem(context.requestId, item.id);
+                return context.data.item.getItem(item.id);
             });
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -274,11 +274,11 @@ module.exports = {
     },
     TaskObjectiveTaskStatus: {
         task(data, args, context) {
-            return context.data.task.get(context.requestId, data.task);
+            return context.data.task.get(data.task);
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -287,11 +287,11 @@ module.exports = {
     },
     TaskObjectiveTraderLevel: {
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id);
+            return context.data.trader.get(data.trader_id);
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -300,11 +300,11 @@ module.exports = {
     },
     TaskObjectiveTraderStanding: {
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id);
+            return context.data.trader.get(data.trader_id);
         },
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
@@ -314,14 +314,14 @@ module.exports = {
     TaskObjectiveUseItem: {
         maps(data, args, context) {
             return data.map_ids.map(id => {
-                return context.data.map.get(context.requestId, id);
+                return context.data.map.get(id);
             });
         },
         description(data, args, context, info) {
             return context.util.getLocale(data, 'description', info);
         },
         useAny(data, args, context) {
-            return Promise.all(data.useAny.map(id => context.data.item.getItem(context.requestId, id)));
+            return Promise.all(data.useAny.map(id => context.data.item.getItem(id)));
         },
         zoneNames(data, args, context, info) {
             return context.util.getLocale(data, 'zoneNames', info);
@@ -341,7 +341,7 @@ module.exports = {
     TaskRewards: {
         traderUnlock(data, args, context) {
             return Promise.all(data.traderUnlock.map(unlock => {
-                return context.data.trader.get(context.requestId, unlock.trader_id);
+                return context.data.trader.get(unlock.trader_id);
             }));
         },
         async craftUnlock(data, args, context) {
@@ -351,7 +351,7 @@ module.exports = {
             if (data.craftUnlock.length === 0) {
                 return [];
             }
-            const crafts = await context.data.craft.getList(context.requestId);
+            const crafts = await context.data.craft.getList();
             return data.craftUnlock.map(unlock => {
                 return crafts.find(c => {
                     if (c.station !== unlock.station_id || c.level !== unlock.level) {
@@ -367,31 +367,31 @@ module.exports = {
     },
     TaskStatusRequirement: {
         task(data, args, context) {
-            return context.data.task.get(context.requestId, data.task);
+            return context.data.task.get(data.task);
         }
     },
     OfferUnlock: {
         item(data, args, context) {
-            if (data.contains && Array.isArray(data.contains) && data.contains.length > 0) return context.data.item.getItem(context.requestId, data.item, data.contains);
-            return context.data.item.getItem(context.requestId, data.item);
+            if (data.contains && Array.isArray(data.contains) && data.contains.length > 0) return context.data.item.getItem(data.item, data.contains);
+            return context.data.item.getItem(data.item);
         },
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id)
+            return context.data.trader.get(data.trader_id)
         }
     },
     Quest: {
         giver(data, args, context) {
-            return context.data.trader.get(context.requestId, context.data.trader.getDataIdMap()[data.giver]);
+            return context.data.trader.get(context.data.trader.getDataIdMap()[data.giver]);
         },
         turnin(data, args, context) {
-            return context.data.trader.get(context.requestId, context.data.trader.getDataIdMap()[data.turnin]);
+            return context.data.trader.get(context.data.trader.getDataIdMap()[data.turnin]);
         }
     },
     QuestObjective: {
         async targetItem(data, args, context) {
             if (!data.targetItem) return null;
             try {
-                return await context.data.item.getItem(context.requestId, data.targetItem)
+                return await context.data.item.getItem(data.targetItem)
             } catch (error) {
                 if (error.message.includes('No item found with id')) return null;
                 return Promise.reject(error);
@@ -402,14 +402,14 @@ module.exports = {
         prerequisiteQuests(data, args, context) {
             return data.prerequisiteQuests.map(questArray => {
                 return questArray.map(questId => {
-                    return context.data.task.getQuest(context.requestId, questId);
+                    return context.data.task.getQuest(questId);
                 });
             });
         }
     },
     QuestRewardReputation: {
         async trader(data, args, context) {
-            return context.data.trader.get(context.requestId, context.data.trader.getDataIdMap()[data.trader]);
+            return context.data.trader.get(context.data.trader.getDataIdMap()[data.trader]);
         }
     }
 };

--- a/resolvers/traderResolver.js
+++ b/resolvers/traderResolver.js
@@ -1,10 +1,10 @@
 module.exports = {
     Query: {
         traders(obj, args, context, info) {
-            return context.util.paginate(context.data.trader.getList(context.requestId), args);
+            return context.util.paginate(context.data.trader.getList(), args);
         },
         traderResetTimes: (obj, args, context) => {
-            return context.data.trader.getTraderResets(context.requestId);
+            return context.data.trader.getTraderResets();
         },
     },
     Trader: {
@@ -15,70 +15,70 @@ module.exports = {
             return context.util.getLocale(data, 'description', info);
         },
         currency(trader, args, context) {
-            return context.data.item.getItem(context.requestId, context.data.trader.getCurrencyMap()[trader.currency]);
+            return context.data.item.getItem(context.data.trader.getCurrencyMap()[trader.currency]);
         },
         barters(data, args, context, info) {
             context.util.testDepthLimit(info, 1);
-            return context.data.barter.getBartersForTrader(context.requestId, data.id);
+            return context.data.barter.getBartersForTrader(data.id);
         },
         cashOffers(data, args, context, info) {
             context.util.testDepthLimit(info, 1);
-            return context.data.traderInventory.getPricesForTrader(context.requestId, data.id);
+            return context.data.traderInventory.getPricesForTrader(data.id);
         }
     },
     TraderLevel: {
         barters(data, args, context, info) {
             context.util.testDepthLimit(info, 2);
-            return context.data.barter.getBartersForTraderLevel(context.requestId, data.id.substring(0, data.id.indexOf('-')), data.level);
+            return context.data.barter.getBartersForTraderLevel(data.id.substring(0, data.id.indexOf('-')), data.level);
         },
         cashOffers(data, args, context, info) {
             context.util.testDepthLimit(info, 2);
-            return context.data.traderInventory.getPricesForTraderLevel(context.requestId, data.id.substring(0, data.id.indexOf('-')), data.level);
+            return context.data.traderInventory.getPricesForTraderLevel(data.id.substring(0, data.id.indexOf('-')), data.level);
         }
     },
     TraderCashOffer: {
         item(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.id);
+            return context.data.item.getItem(data.id);
         },
         minTraderLevel(data) {
             return data.vendor.traderLevel;
         },
         currencyItem(data, args, context) {
-            return context.data.item.getItem(context.requestId, data.currencyItem);
+            return context.data.item.getItem(data.currencyItem);
         },
         taskUnlock(data, args, context) {
-            if (data.vendor.taskUnlock) return context.data.task.get(context.requestId, data.vendor.taskUnlock);
+            if (data.vendor.taskUnlock) return context.data.task.get(data.vendor.taskUnlock);
             return null;
         }
     },
     TraderOffer: {
         async name(data, args, context, info) {
-            return context.util.getLocale(await context.data.trader.get(context.requestId, data.trader_id), 'name', info);
+            return context.util.getLocale(await context.data.trader.get(data.trader_id), 'name', info);
         },
         async normalizedName(data, args, context) {
-            return (await context.data.trader.get(context.requestId, data.trader_id)).normalizedName;
+            return (await context.data.trader.get(data.trader_id)).normalizedName;
         },
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id);
+            return context.data.trader.get(data.trader_id);
         },
         taskUnlock(data, args, context) {
-            if (data.taskUnlock) return context.data.task.get(context.requestId, data.taskUnlock);
+            if (data.taskUnlock) return context.data.task.get(data.taskUnlock);
             return null;
         },
     },
     TraderPrice: {
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader);
+            return context.data.trader.get(data.trader);
         }
     },
     RequirementTrader: {
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id);
+            return context.data.trader.get(data.trader_id);
         }
     },
     TraderStanding: {
         trader(data, args, context) {
-            return context.data.trader.get(context.requestId, data.trader_id);
+            return context.data.trader.get(data.trader_id);
         }
     }
 };

--- a/schema_dynamic.js
+++ b/schema_dynamic.js
@@ -1,8 +1,8 @@
-module.exports = async (data, requestId) => {
-    const itemTypes = await data.schema.getItemTypes(requestId);
-    const categories = await data.schema.getCategories(requestId);
-    const handbookCategories = await data.schema.getHandbookCategories(requestId);
-    const languageCodes = await data.schema.getLanguageCodes(requestId);
+module.exports = async (data) => {
+    const itemTypes = await data.schema.getItemTypes();
+    const categories = await data.schema.getCategories();
+    const handbookCategories = await data.schema.getHandbookCategories();
+    const languageCodes = await data.schema.getLanguageCodes();
     return `
 enum ItemType {
     ${itemTypes}

--- a/utils/worker-kv.js
+++ b/utils/worker-kv.js
@@ -17,62 +17,18 @@ class WorkerKV {
         this.cache = false;
         this.loading = false;
         this.kvName = kvName;
-        this.loadingPromises = {};
-        this.loadingInterval = false;
         this.dataExpires = false;
         this.dataSource = dataSource;
     }
 
-    async init(requestId) {
-        if (this.cache && (!this.dataExpires || new Date() < this.dataExpires)) {
-            //console.log(`${this.kvName} is fresh; not refreshing`);
-            this.dataSource.setKvUsedForRequest(this.kvName, requestId);
-            return;
-        }
-        if (this.dataSource.kvLoadedForRequest(this.kvName, requestId)) {
-            //console.log(`${this.kvName} already loaded for request ${requestId}; not refreshing`);
-            return;
-        }
+    async init() {
         if (this.cache) {
-            console.log(`${this.kvName} is stale; re-loading`);
-            this.cache = false;
-            this.loading = false;
-        } else {
-            //console.log(`${this.kvName} loading`);
+            return;
         }
         if (this.loading) {
-            if (this.loadingPromises[requestId]) {
-                return this.loadingPromises[requestId];
-            }
-            //console.log(`${this.kvName} already loading; awaiting load`);
-            this.loadingPromises[requestId] = new Promise((resolve) => {
-                const startLoad = new Date();
-                let loadingTimedOut = false;
-                const loadingTimeout = setTimeout(() => {
-                    loadingTimedOut = true;
-                }, 3000);
-                const loadingInterval = setInterval(() => {
-                    if (this.loading === false) {
-                        clearTimeout(loadingTimeout);
-                        clearInterval(loadingInterval);
-                        console.log(`${this.kvName} load: ${new Date() - startLoad} ms (secondary)`);
-                        delete this.loadingPromises[requestId];
-                        this.dataSource.setKvUsedForRequest(this.kvName, requestId);
-                        return resolve();
-                    }
-                    if (loadingTimedOut) {
-                        console.log(`${this.kvName} loading timed out; forcing load`);
-                        clearInterval(loadingInterval);
-                        this.loading = false;
-                        delete this.loadingPromises[requestId];
-                        return resolve(this.init(requestId));
-                    }
-                }, 100);
-            });
-            return this.loadingPromises[requestId];
+            return this.loading;
         }
-        this.loading = true;
-        this.loadingPromises[requestId] = new Promise((resolve, reject) => {
+        this.loading = new Promise((resolve, reject) => {
             const startLoad = new Date();
             DATA_CACHE.getWithMetadata(this.kvName, 'text').then(async response => {
                 console.log(`${this.kvName} load: ${new Date() - startLoad} ms`);
@@ -94,16 +50,15 @@ class WorkerKV {
                     console.log(`${this.kvName} is still stale after re-load`);
                 }
                 this.dataExpires = newDataExpires;
-                this.dataSource.setKvLoadedForRequest(this.kvName, requestId);
+                this.dataSource.setKvUsed(this.kvName);
                 this.loading = false;
-                delete this.loadingPromises[requestId];
                 resolve();
             }).catch(error => {
                 this.loading = false;
                 reject(error);
             });
         });
-        return this.loadingPromises[requestId];
+        return this.loading;
     }
 }
 


### PR DESCRIPTION
This PR attempts to solve the API instability by requiring each request to make its own reads of the KV. We will incur higher KV reads, but it may make the API more stable. Will be deploying to compare stability. Should not be merged until we are satisfied it's a better solution.

There's currently a hanging promise somewhere in here that prevents proper execution.