### PR TITLE
Deployment Updates - CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,23 @@ permissions:
   contents: read
 
 jobs:
+  deployment-check:
+    runs-on: ubuntu-latest
+    outputs: # set outputs for use in downstream jobs
+      continue: ${{ steps.deployment-check.outputs.continue }}
+
+    steps:
+      # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
+      - name: deployment check
+        uses: github/branch-deploy@v6.0.0
+        id: deployment-check
+        with:
+          merge_deploy_mode: "true"
+          environment: production
+
   deploy:
+    if: ${{ needs.deployment-check.outputs.continue == 'true' }}
+    needs: deployment-check
     environment: production
     runs-on: ubuntu-latest
 

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -1,0 +1,22 @@
+# https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/unlock-on-merge.md
+
+name: Unlock On Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  unlock-on-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: unlock on merge
+        uses: github/branch-deploy@v6.0.0
+        id: unlock-on-merge
+        with:
+          unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow
+          environment_targets: production,development

--- a/docs/maintainer-notes.md
+++ b/docs/maintainer-notes.md
@@ -1,0 +1,23 @@
+# Maintainer Notes
+
+This is a living document for the maintainers of this repository.
+
+## Deployment Process
+
+This is a simple run down of how review / deploy a pull request.
+
+1. A pull request is opened
+2. We review the code
+3. We comment `.deploy to development` and ensure the creator of the pull request is happy with the changes
+4. We comment `.deploy` to deploy to production. We "let it bake" and ensure everything is working as expected for a few minutes to a few days depending on the complexity of the changes.
+5. We approve the pull request and merge it into `main`
+
+> It should be noted that the approval step can come before the deployment steps if that suits the situation better.
+
+## CI Failures
+
+A known issue (I am not sure of the cause) for CI failures is when dependabot opens a pull request. For some very strange reason, the necessary secrets are not injected into the Actions workflow when the pull request comes from dependabot. This causes the wrangler environment in CI to fail because it lacks the proper credentials to authenticate with Cloudflare.
+
+The fix: Simply push a commit to the branch in question. It can be an empty commit if you like. This will trigger the CI workflow again and the secrets will be injected properly.
+
+IDK why this happens, but it does. ¯\\\_(ツ)\_/¯


### PR DESCRIPTION
# Deployment Updates - CI

This pull request updates our Actions workflows to incorporate two new "alternate" workflow types that I recently bundled into the branch deploy Action:

- merge commit workflow: This workflow type checks merge commits to prevent re-running a deployment when a PR is merged to `main` if its SHA matches the latest deployment
- unlock on merge workflow: This workflow type releases any sticky locks that are associated to a pull request when that pull request is merged

---

I also figured out why CI is failing but only on dependabot PRs. So I created a new `.md` file to document this.