### PR TITLE
Add armor slots

### DIFF
--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -210,6 +210,36 @@ module.exports = {
             return data.inspectImageLink;
         }
     },
+    ItemArmorSlot: {
+        __resolveType(data) {
+            if (data.allowedPlates) return 'ItemArmorSlotOpen';
+            return 'ItemArmorSlotLocked';
+        }
+    },
+    ItemArmorSlotLocked: {
+        name(data) {
+            if (data.name) return data.name;
+            return data.type;
+        },
+        zones(data, args, context, info) {
+            return context.data.item.getLocale(data.zones, context, info);
+        },
+        material(data, args, context) {
+            return context.data.item.getArmorMaterial(context, data.armor_material_id);
+        },
+    },
+    ItemArmorSlotOpen: {
+        name(data) {
+            if (data.name) return data.name;
+            return data.type;
+        },
+        zones(data, args, context, info) {
+            return context.data.item.getLocale(data.zones, context, info);
+        },
+        allowedPlates(data, args, context) {
+            return data.allowedPlates.map(id => context.data.item.getItem(context, id));
+        },
+    },
     ItemAttribute: {
         type(data, args, context) {
             if (data.type) return data.type;

--- a/schema.js
+++ b/schema.js
@@ -1287,6 +1287,11 @@ type TraderReputationLevelFence {
   hostileScavs: Boolean
   scavAttackSupport: Boolean
   availableScavExtracts: Int
+  btrEnabled: Boolean
+  btrDeliveryDiscount: Int
+  btrDeliveryGridSize: MapPosition
+  btrTaxiDiscount: Int
+  btrCoveringFireDiscount: Int
 }
 
 type TraderStanding {

--- a/schema.js
+++ b/schema.js
@@ -274,6 +274,34 @@ type Item {
   gridImageLinkFallback: String! @deprecated(reason: "Fallback handled automatically by gridImageLink.")
 }
 
+interface ItemArmorSlot {
+  #id: ID!
+  nameId: String
+  zones: [String]
+}
+
+type ItemArmorSlotLocked implements ItemArmorSlot {
+  nameId: String
+  name: String
+  bluntThroughput: Float
+  class: Int
+  durability: Int
+  repairCost: Int
+  speedPenalty: Float
+  turnPenalty: Float
+  ergoPenalty: Float
+  material: ArmorMaterial
+  zones: [String]
+  armorType: String
+}
+
+type ItemArmorSlotOpen implements ItemArmorSlot {
+  nameId: String
+  name: String
+  zones: [String]
+  allowedPlates: [Item]
+}
+
 type ItemAttribute {
   type: String!
   name: String!
@@ -344,6 +372,7 @@ type ItemPropertiesArmor {
   material: ArmorMaterial
   armorType: String
   bluntThroughput: Float
+  armorSlots: [ItemArmorSlot]
 }
 
 type ItemPropertiesArmorAttachment {
@@ -394,6 +423,7 @@ type ItemPropertiesChestRig {
   pouches: [ItemStorageGrid] @deprecated(reason: "Use grids instead.")
   armorType: String
   bluntThroughput: Float
+  armorSlots: [ItemArmorSlot]
 }
 
 type ItemPropertiesContainer {
@@ -462,6 +492,7 @@ type ItemPropertiesHelmet {
   ricochetZ: Float
   armorType: String
   bluntThroughput: Float
+  armorSlots: [ItemArmorSlot]
 }
 
 type ItemPropertiesKey {

--- a/schema.js
+++ b/schema.js
@@ -293,6 +293,7 @@ type ItemArmorSlotLocked implements ItemArmorSlot {
   material: ArmorMaterial
   zones: [String]
   armorType: String
+  baseValue: Int
 }
 
 type ItemArmorSlotOpen implements ItemArmorSlot {


### PR DESCRIPTION
Armor slots are either open (e.g., customizable) or locked (e.g., have built-in armor pieces that can't be changed). Open armor slots have an allowedPlates property that lists all the plate items that can be put into that armor slot. Locked armor slots have all the armor attributes available directly in the slot because they can't be customized.