### PR TITLE
lay groundwork for archived prices

### DIFF
--- a/datasources/archived-prices.js
+++ b/datasources/archived-prices.js
@@ -1,0 +1,23 @@
+const WorkerKVSplit = require('../utils/worker-kv-split');
+
+class ArchivedPricesAPI extends WorkerKVSplit {
+    constructor(dataSource) {
+        super('archived_price_data', dataSource);
+    }
+
+    async getByItemId(context, itemId) {
+        await this.init(context, itemId);
+        const data = await this.getKVData(context, itemId);
+        if (!data) {
+            return Promise.reject(new Error('Archived prices data is empty'));
+        }
+        
+        let prices = data.ArchivedPrices[itemId];
+        if (!prices) {
+            return [];
+        }
+        return prices;
+    }
+}
+
+module.exports = ArchivedPricesAPI;

--- a/datasources/index.js
+++ b/datasources/index.js
@@ -2,6 +2,7 @@ const BartersAPI = require('./barters');
 const CraftsAPI = require('./crafts');
 const HideoutAPI = require('./hideout');
 const HistoricalPricesAPI = require('./historical-prices');
+const ArchivedPricesAPI = require('./archived-prices');
 const ItemsAPI = require('./items');
 const MapAPI = require('./maps');
 const SchemaAPI = require('./schema');
@@ -16,6 +17,7 @@ class DataSource {
         this.craft = new CraftsAPI(this);
         this.hideout = new HideoutAPI(this);
         this.historicalPrice = new HistoricalPricesAPI(this);
+        this.archivedPrice = new ArchivedPricesAPI(this);
         this.item = new ItemsAPI(this);
         this.map = new MapAPI(this);
         this.schema = new SchemaAPI(this);
@@ -34,6 +36,7 @@ class DataSource {
             craft: this.craft,
             hideout: this.hideout,
             historicalPrice: this.historicalPrice,
+            archivedPrice: this.archivedPrice,
             item: this.item,
             map: this.map,
             schema: this.schema,

--- a/resolvers/itemResolver.js
+++ b/resolvers/itemResolver.js
@@ -78,6 +78,9 @@ module.exports = {
         historicalItemPrices(obj, args, context, info) {
             return context.util.paginate(context.data.historicalPrice.getByItemId(context, args.id, args.days), args);
         },
+        /*archivedItemPrices(obj, args, context, info) {
+            return context.util.paginate(context.data.archivedPrice.getByItemId(context, args.id), args);
+        },*/
         armorMaterials(obj, args, context) {
             return context.data.item.getArmorMaterials(context);
         },

--- a/schema.js
+++ b/schema.js
@@ -1306,7 +1306,8 @@ interface Vendor {
 #union Vendor = TraderOffer | FleaMarket
 
 type Query {
-  ammo(lang: LanguageCode, limit: Int, offset: Int): [Ammo]  
+  ammo(lang: LanguageCode, limit: Int, offset: Int): [Ammo]
+  #archivedItemPrices(id: ID!, limit: Int, offset: Int): [historicalPricePoint]!
   barters(lang: LanguageCode, limit: Int, offset: Int): [Barter]
   bosses(lang: LanguageCode, name: [String!], limit: Int, offset: Int): [MobInfo]
   crafts(lang: LanguageCode, limit: Int, offset: Int): [Craft]

--- a/utils/worker-kv-split.js
+++ b/utils/worker-kv-split.js
@@ -1,0 +1,39 @@
+const WorkerKV = require('./worker-kv');
+
+class WorkerKVSplit {
+    constructor(kvName, dataSource, idLength = 1) {
+        this.dataExpires = false;
+        this.kvs = {};
+        this.idLength = idLength;
+        const hexKeys = [];
+        const maxDecimalValue = parseInt('f'.padEnd(idLength, 'f'), 16);
+        for (let i = 0; i <= maxDecimalValue; i++) {
+            const hexValue = i.toString(16).padStart(idLength, '0');
+            hexKeys.push(hexValue);
+        }
+        for (const hexKey of hexKeys) {
+            this.kvs[hexKey] = new WorkerKV(`${kvName}_${hexKey}`, dataSource);
+        }
+    }
+
+    getIdSuffix(id) {
+        return id.substring(id.length-this.idLength, id.length);
+    }
+
+    async init(context, id) {
+        const kvId = this.getIdSuffix(id);
+        return this.kvs[kvId].init(context).then(() => {
+            if (this.kvs[kvId].cache?.expiration) {
+                this.dataExpiress = new Date(this.kvs[kvId].cache.expiration).valueOf();
+            }
+        });
+    }
+
+    async getKVData(context, id) {
+        await this.init(context, id);
+        const kvId = this.getIdSuffix(id);
+        return this.kvs[kvId].cache;
+    }
+}
+
+module.exports = WorkerKVSplit;


### PR DESCRIPTION
Adds needed functions to support archived prices split across multiple KVs according to the trailing character of item ids. Does not actually enable any new queries yet since we are still processing all the old price data.