### PR TITLE
change armor plates to use zones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
             "dependencies": {
                 "@graphql-tools/merge": "9.0.4",
                 "@graphql-tools/schema": "10.0.4",
-                "graphql": "^16.8.1",
-                "uuid": "9.0.1"
+                "graphql": "^16.8.2",
+                "uuid": "^10.0.0"
             },
             "devDependencies": {
                 "newman": "^6.1.2",
@@ -757,9 +757,9 @@
             }
         },
         "node_modules/aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
+            "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
             "dev": true
         },
         "node_modules/base64-js": {
@@ -813,12 +813,12 @@
             "dev": true
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -904,9 +904,9 @@
             }
         },
         "node_modules/cli-table3": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-            "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "dev": true,
             "dependencies": {
                 "string-width": "^4.2.0"
@@ -1162,18 +1162,18 @@
             }
         },
         "node_modules/filesize": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.0.tgz",
-            "integrity": "sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.2.tgz",
+            "integrity": "sha512-Dx770ai81ohflojxhU+oG+Z2QGvKdYxgEr9OSA8UVrqhwNHjfH9A8f5NKfg83fEH8ZFA5N5llJo5T3PIoZ4CRA==",
             "dev": true,
             "engines": {
                 "node": ">= 10.4.0"
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
@@ -1258,9 +1258,9 @@
             "dev": true
         },
         "node_modules/graphql": {
-            "version": "16.8.1",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==",
+            "version": "16.8.2",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.2.tgz",
+            "integrity": "sha512-cvVIBILwuoSyD54U4cF/UXDh5yAobhNV/tPygI4lZhgOIJQE/WLWC4waBRb4I6bDVYb3OVx3lfHbaQOEoUD5sg==",
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
@@ -1702,29 +1702,29 @@
             "dev": true
         },
         "node_modules/newman": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/newman/-/newman-6.1.2.tgz",
-            "integrity": "sha512-VyaXFguIYM7QUWXHQlHtkj3axzZQFHgj9OYkhbKpq4iphKAJckHFstltacSBtgpeiGp5SKk9FBdCYVbJXcLvnQ==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/newman/-/newman-6.1.3.tgz",
+            "integrity": "sha512-Zv+BjkJsYwSwc4oE3o40W6enBZRS7a7OL3aB8c4e46tDvg4HCOh6EhsmQmYhSMmlYF2JBieYiqS7XUwWkY6PiQ==",
             "dev": true,
             "dependencies": {
                 "@postman/tough-cookie": "4.1.3-postman.1",
                 "async": "3.2.5",
                 "chardet": "2.0.0",
                 "cli-progress": "3.12.0",
-                "cli-table3": "0.6.3",
+                "cli-table3": "0.6.5",
                 "colors": "1.4.0",
                 "commander": "11.1.0",
                 "csv-parse": "4.16.3",
-                "filesize": "10.1.0",
+                "filesize": "10.1.2",
                 "liquid-json": "0.3.1",
                 "lodash": "4.17.21",
                 "mkdirp": "3.0.1",
                 "postman-collection": "4.4.0",
                 "postman-collection-transformer": "4.1.8",
                 "postman-request": "2.88.1-postman.33",
-                "postman-runtime": "7.37.1",
+                "postman-runtime": "7.39.0",
                 "pretty-ms": "7.0.1",
-                "semver": "7.6.0",
+                "semver": "7.6.2",
                 "serialised-error": "1.1.3",
                 "word-wrap": "1.2.5",
                 "xmlbuilder": "15.1.1"
@@ -1737,13 +1737,10 @@
             }
         },
         "node_modules/newman/node_modules/semver": {
-            "version": "7.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-            "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -1934,9 +1931,9 @@
             }
         },
         "node_modules/postman-runtime": {
-            "version": "7.37.1",
-            "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.37.1.tgz",
-            "integrity": "sha512-yqKN/p6Ba8+yq9iZsxJLkMPko3lKvs3hixkiPy5O7bapFQWgX6jWhny4W2O8BzE5T8KzE8s1HAgT2gi7e2Y5Jg==",
+            "version": "7.39.0",
+            "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.39.0.tgz",
+            "integrity": "sha512-FMfHHdbBlCB7hno8AHWEfVItVHk+/NaV3NeedVMNEtLnTeNTjKtDZ29LMmIikW4O+mmToh2l46qYH2iw72TtEQ==",
             "dev": true,
             "dependencies": {
                 "@postman/tough-cookie": "4.1.3-postman.1",
@@ -1953,7 +1950,7 @@
                 "performance-now": "2.1.0",
                 "postman-collection": "4.4.0",
                 "postman-request": "2.88.1-postman.33",
-                "postman-sandbox": "4.6.0",
+                "postman-sandbox": "4.7.1",
                 "postman-url-encoder": "3.0.5",
                 "serialised-error": "1.1.3",
                 "strip-json-comments": "3.1.1",
@@ -1962,6 +1959,12 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/postman-runtime/node_modules/aws4": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+            "dev": true
         },
         "node_modules/postman-runtime/node_modules/uuid": {
             "version": "8.3.2",
@@ -1973,9 +1976,9 @@
             }
         },
         "node_modules/postman-sandbox": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.6.0.tgz",
-            "integrity": "sha512-+tCUEhiFAV6saqMEetRzLmSWt4/9kgVagtnrVgyqVgIGdPBIaq1p3aay54bOzYW7/QjIIz0xPF3YkJA8Olt3LQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.7.1.tgz",
+            "integrity": "sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==",
             "dev": true,
             "dependencies": {
                 "lodash": "4.17.21",
@@ -2372,9 +2375,9 @@
             "dev": true
         },
         "node_modules/uglify-js": {
-            "version": "3.17.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "version": "3.18.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+            "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
             "dev": true,
             "optional": true,
             "bin": {
@@ -2431,9 +2434,9 @@
             }
         },
         "node_modules/uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
             "funding": [
                 "https://github.com/sponsors/broofa",
                 "https://github.com/sponsors/ctavan"
@@ -3032,9 +3035,9 @@
             "dev": true
         },
         "aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
+            "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
             "dev": true
         },
         "base64-js": {
@@ -3071,12 +3074,12 @@
             "dev": true
         },
         "braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "requires": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             }
         },
         "brotli": {
@@ -3142,9 +3145,9 @@
             }
         },
         "cli-table3": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-            "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "dev": true,
             "requires": {
                 "@colors/colors": "1.5.0",
@@ -3338,15 +3341,15 @@
             "dev": true
         },
         "filesize": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.0.tgz",
-            "integrity": "sha512-GTLKYyBSDz3nPhlLVPjPWZCnhkd9TrrRArNcy8Z+J2cqScB7h2McAzR6NBX6nYOoWafql0roY8hrocxnZBv9CQ==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/filesize/-/filesize-10.1.2.tgz",
+            "integrity": "sha512-Dx770ai81ohflojxhU+oG+Z2QGvKdYxgEr9OSA8UVrqhwNHjfH9A8f5NKfg83fEH8ZFA5N5llJo5T3PIoZ4CRA==",
             "dev": true
         },
         "fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
@@ -3412,9 +3415,9 @@
             "dev": true
         },
         "graphql": {
-            "version": "16.8.1",
-            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.1.tgz",
-            "integrity": "sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw=="
+            "version": "16.8.2",
+            "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.8.2.tgz",
+            "integrity": "sha512-cvVIBILwuoSyD54U4cF/UXDh5yAobhNV/tPygI4lZhgOIJQE/WLWC4waBRb4I6bDVYb3OVx3lfHbaQOEoUD5sg=="
         },
         "handlebars": {
             "version": "4.7.8",
@@ -3738,42 +3741,39 @@
             "dev": true
         },
         "newman": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/newman/-/newman-6.1.2.tgz",
-            "integrity": "sha512-VyaXFguIYM7QUWXHQlHtkj3axzZQFHgj9OYkhbKpq4iphKAJckHFstltacSBtgpeiGp5SKk9FBdCYVbJXcLvnQ==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/newman/-/newman-6.1.3.tgz",
+            "integrity": "sha512-Zv+BjkJsYwSwc4oE3o40W6enBZRS7a7OL3aB8c4e46tDvg4HCOh6EhsmQmYhSMmlYF2JBieYiqS7XUwWkY6PiQ==",
             "dev": true,
             "requires": {
                 "@postman/tough-cookie": "4.1.3-postman.1",
                 "async": "3.2.5",
                 "chardet": "2.0.0",
                 "cli-progress": "3.12.0",
-                "cli-table3": "0.6.3",
+                "cli-table3": "0.6.5",
                 "colors": "1.4.0",
                 "commander": "11.1.0",
                 "csv-parse": "4.16.3",
-                "filesize": "10.1.0",
+                "filesize": "10.1.2",
                 "liquid-json": "0.3.1",
                 "lodash": "4.17.21",
                 "mkdirp": "3.0.1",
                 "postman-collection": "4.4.0",
                 "postman-collection-transformer": "4.1.8",
                 "postman-request": "2.88.1-postman.33",
-                "postman-runtime": "7.37.1",
+                "postman-runtime": "7.39.0",
                 "pretty-ms": "7.0.1",
-                "semver": "7.6.0",
+                "semver": "7.6.2",
                 "serialised-error": "1.1.3",
                 "word-wrap": "1.2.5",
                 "xmlbuilder": "15.1.1"
             },
             "dependencies": {
                 "semver": {
-                    "version": "7.6.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-                    "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-                    "dev": true,
-                    "requires": {
-                        "lru-cache": "^6.0.0"
-                    }
+                    "version": "7.6.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+                    "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+                    "dev": true
                 }
             }
         },
@@ -3924,9 +3924,9 @@
             }
         },
         "postman-runtime": {
-            "version": "7.37.1",
-            "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.37.1.tgz",
-            "integrity": "sha512-yqKN/p6Ba8+yq9iZsxJLkMPko3lKvs3hixkiPy5O7bapFQWgX6jWhny4W2O8BzE5T8KzE8s1HAgT2gi7e2Y5Jg==",
+            "version": "7.39.0",
+            "resolved": "https://registry.npmjs.org/postman-runtime/-/postman-runtime-7.39.0.tgz",
+            "integrity": "sha512-FMfHHdbBlCB7hno8AHWEfVItVHk+/NaV3NeedVMNEtLnTeNTjKtDZ29LMmIikW4O+mmToh2l46qYH2iw72TtEQ==",
             "dev": true,
             "requires": {
                 "@postman/tough-cookie": "4.1.3-postman.1",
@@ -3943,13 +3943,19 @@
                 "performance-now": "2.1.0",
                 "postman-collection": "4.4.0",
                 "postman-request": "2.88.1-postman.33",
-                "postman-sandbox": "4.6.0",
+                "postman-sandbox": "4.7.1",
                 "postman-url-encoder": "3.0.5",
                 "serialised-error": "1.1.3",
                 "strip-json-comments": "3.1.1",
                 "uuid": "8.3.2"
             },
             "dependencies": {
+                "aws4": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+                    "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+                    "dev": true
+                },
                 "uuid": {
                     "version": "8.3.2",
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -3959,9 +3965,9 @@
             }
         },
         "postman-sandbox": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.6.0.tgz",
-            "integrity": "sha512-+tCUEhiFAV6saqMEetRzLmSWt4/9kgVagtnrVgyqVgIGdPBIaq1p3aay54bOzYW7/QjIIz0xPF3YkJA8Olt3LQ==",
+            "version": "4.7.1",
+            "resolved": "https://registry.npmjs.org/postman-sandbox/-/postman-sandbox-4.7.1.tgz",
+            "integrity": "sha512-H2wYSLK0mB588IaxoLrLoPbpmxsIcwFtgaK2c8gAsAQ+TgYFePwb4qdeVcYDMqmwrLd77/ViXkjasP/sBMz1sQ==",
             "dev": true,
             "requires": {
                 "lodash": "4.17.21",
@@ -4253,9 +4259,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.17.4",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-            "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+            "version": "3.18.0",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.18.0.tgz",
+            "integrity": "sha512-SyVVbcNBCk0dzr9XL/R/ySrmYf0s372K6/hFklzgcp2lBFyXtw4I7BOdDjlLhE1aVqaI/SHWXWmYdlZxuyF38A==",
             "dev": true,
             "optional": true
         },
@@ -4300,9 +4306,9 @@
             }
         },
         "uuid": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+            "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="
         },
         "uvm": {
             "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@graphql-tools/merge": "9.0.4",
         "@graphql-tools/schema": "10.0.4",
-        "graphql": "^16.8.1",
-        "uuid": "9.0.1"
+        "graphql": "^16.8.2",
+        "uuid": "^10.0.0"
     }
 }

--- a/resolvers/itemResolver.mjs
+++ b/resolvers/itemResolver.mjs
@@ -313,6 +313,9 @@ export default {
         },
         headZones(data, args, context, info) {
             return context.data.item.getLocale(data.headZones, context, info);
+        },
+        zones(data, args, context, info) {
+            return context.data.item.getLocale(data.headZones, context, info);
         }
     },
     ItemPropertiesBackpack: {

--- a/schema.mjs
+++ b/schema.mjs
@@ -402,12 +402,13 @@ type ItemPropertiesArmorAttachment {
   speedPenalty: Float
   turnPenalty: Float
   ergoPenalty: Float
-  headZones: [String]
+  zones: [String]
   material: ArmorMaterial
   armorType: String
   blindnessProtection: Float
   bluntThroughput: Float
   slots: [ItemSlot]
+  headZones: [String] @deprecated(reason: "Use zones instead.")
 }
 
 type ItemPropertiesBackpack {


### PR DESCRIPTION
Previously `ItemPropertiesArmorAttachment` was only used by helmet attachments, so the zones field was called `headZones`. Since armor plates use this same properties type, this PR deprecates `headZones` and introduces `zones` in its place.