### PR TITLE
warn when using deprecated queries

### DIFF
--- a/resolvers/hideoutResolver.mjs
+++ b/resolvers/hideoutResolver.mjs
@@ -1,6 +1,7 @@
 export default {
     Query: {
         hideoutModules(obj, args, context, info) {
+            context.warnings.push(`The hideoutModules query is deprecated and provided only for backwards compatibility purposes. Please use the hideoutStations query, which includes the latest hideout information.`);
             return context.data.hideout.getLegacyList(context);
         },
         hideoutStations(obj, args, context, info) {

--- a/resolvers/taskResolver.mjs
+++ b/resolvers/taskResolver.mjs
@@ -19,6 +19,7 @@ export default {
             return context.data.task.get(context, args.id);
         },
         quests(obj, args, context, info) {
+            context.warnings.push(`The quests query is deprecated and provided only for backwards compatibility purposes. Please use the tasks query, which includes the latest quests/tasks information.`);
             return context.data.task.getQuests(context);
         },
         questItems(obj, args, context) {


### PR DESCRIPTION
Add warning to API response when deprecated `quests` and `hideoutModules` queries are used.