### PR TITLE
Treat dedicated server as origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,6 @@ Prerequisites:
 You may want to create a .dev.vars file in the main project folder with the following values:
 
 - CACHE_BASIC_AUTH (used for caching)
-- HTTP_GRAPHQL_SERVER (the address to the dedicated graphql server; must be https and a domain - not an IP address)
 
 Start the API server:
 

--- a/index.mjs
+++ b/index.mjs
@@ -109,9 +109,9 @@ async function graphqlHandler(request, env, ctx) {
     }
 
     // if an HTTP GraphQL server is configured, pass the request to that
-    if (env.HTTP_GRAPHQL_SERVER) {
+    if (env.USE_ORIGIN === 'true') {
         try {
-            const serverUrl = `${env.HTTP_GRAPHQL_SERVER}${graphQLOptions.baseEndpoint}`;
+            const serverUrl = `https://api.tarkov.dev${graphQLOptions.baseEndpoint}`;
             const queryResult = await fetch(serverUrl, {
                 method: request.method,
                 body: JSON.stringify({

--- a/plugins/plugin-http-server.mjs
+++ b/plugins/plugin-http-server.mjs
@@ -4,11 +4,11 @@ export default function useHttpServer(env) {
     return {
         async onParams({params, request, setParams, setResult, fetchAPI}) {
             // if an HTTP GraphQL server is configured, pass the request to that
-            if (!env.HTTP_GRAPHQL_SERVER) {
+            if (env.USE_ORIGIN !== 'true') {
                 return;
             }
             try {
-                const serverUrl = `${env.HTTP_GRAPHQL_SERVER}${graphQLOptions.baseEndpoint}`;
+                const serverUrl = `https://api.tarkov.dev${graphQLOptions.baseEndpoint}`;
                 const queryResult = await fetch(serverUrl, {
                     method: request.method,
                     body: JSON.stringify(params),

--- a/plugins/plugin-use-cache-machine.mjs
+++ b/plugins/plugin-use-cache-machine.mjs
@@ -92,7 +92,7 @@ export default function useCacheMachine(env) {
                 // if the ttl is greater than a half hour, limit it
                 ttl = 1800;
             }
-            if (env.SKIP_CACHE !== 'true' && ttl > 0 && !env.HTTP_GRAPHQL_SERVER) {
+            if (env.SKIP_CACHE !== 'true' && ttl > 0 && env.USE_ORIGIN !== 'true') {
                 // using waitUntil doesn't hold up returning a response but keeps the worker alive as long as needed
                 const cacheBody = JSON.stringify(result);
                 if (cacheBody.length > 0) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,7 +6,7 @@ workers_dev = true
 kv_namespaces = [
     { binding = "DATA_CACHE", id = "2e6feba88a9e4097b6d2209191ed4ae5", preview_id = "17fd725f04984e408d4a70b37c817171" },
 ]
-vars = { ENVIRONMENT = "production" }
+vars = { ENVIRONMENT = "production", USE_ORIGIN = "true" }
 routes = [
 	{ pattern = "api.tarkov.dev/*", zone_name = "tarkov.dev" },
     { pattern = "streamer.tarkov.dev/*", zone_name = "tarkov.dev" }
@@ -16,7 +16,7 @@ routes = [
 kv_namespaces = [
     { binding = "DATA_CACHE", id = "17fd725f04984e408d4a70b37c817171", preview_id = "17fd725f04984e408d4a70b37c817171" },
 ]
-vars = { ENVIRONMENT = "development", SKIP_CACHE = "false" }
+vars = { ENVIRONMENT = "development", USE_ORIGIN = "false", SKIP_CACHE = "false" }
 routes = [
 	{ pattern = "dev-api.tarkov.dev/*", zone_name = "tarkov.dev" },
     { pattern = "dev-streamer.tarkov.dev/*", zone_name = "tarkov.dev" }
@@ -26,4 +26,3 @@ routes = [
 # CACHE_BASIC_AUTH
 # TWITCH_CLIENT_ID
 # TWITCH_TOKEN
-# HTTP_GRAPHQL_SERVER


### PR DESCRIPTION
Treating the dedicated server as origin ensures that the worker always stands in front of it.