### PR TITLE
Don't cache error responses

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -161,6 +161,8 @@ async function graphqlHandler(request, env, ctx) {
 
     if (result.errors?.some(err => err.message === 'Unexpected error.')) {
         ttl = 0;
+    } else if (result.errors?.some(err => err.message.startsWith('Syntax Error'))) {
+        ttl = 1800;
     } else if (specialCache === 'application/json') {
         if (!result.warnings) {
             result = Object.assign({warnings: []}, result);

--- a/index.mjs
+++ b/index.mjs
@@ -159,7 +159,9 @@ async function graphqlHandler(request, env, ctx) {
         result.warnings.push(...context.warnings);
     }
 
-    if (specialCache === 'application/json') {
+    if (result.errors?.some(err => err.message === 'Unexpected error.')) {
+        ttl = 0;
+    } else if (specialCache === 'application/json') {
         if (!result.warnings) {
             result = Object.assign({warnings: []}, result);
         }

--- a/plugins/plugin-use-cache-machine.mjs
+++ b/plugins/plugin-use-cache-machine.mjs
@@ -85,6 +85,8 @@ export default function useCacheMachine(env) {
             const sCache = specialCache(request);
             if (result.errors?.some(err => err.message === 'Unexpected error.')) {
                 ttl = 0;
+            } else if (result.errors?.some(err => err.message.startsWith('Syntax Error'))) {
+                ttl = 1800;
             } else if (sCache === 'application/json') {
                 if (!result.warnings) {
                     result = Object.assign({warnings: []}, result);

--- a/plugins/plugin-use-cache-machine.mjs
+++ b/plugins/plugin-use-cache-machine.mjs
@@ -83,7 +83,9 @@ export default function useCacheMachine(env) {
             let ttl = request.data?.getRequestTtl(request.requestId) ?? 60 * 5;
 
             const sCache = specialCache(request);
-            if (sCache === 'application/json') {
+            if (result.errors?.some(err => err.message === 'Unexpected error.')) {
+                ttl = 0;
+            } else if (sCache === 'application/json') {
                 if (!result.warnings) {
                     result = Object.assign({warnings: []}, result);
                 }

--- a/utils/graphql-util.mjs
+++ b/utils/graphql-util.mjs
@@ -56,7 +56,7 @@ const graphqlUtil =  {
             for (const arg of selection.arguments) {
                 if (arg.name.value === argumentName) {
                     if (arg.value.kind === 'Variable') {
-                        argValue = info.variableValues[argumentName];
+                        argValue = info.variableValues[arg.value.name.value];
                     } else {
                         argValue = arg.value.value;
                     }


### PR DESCRIPTION
When graphql responses include "Unexpected errors", don't cache the results to avoid polluting the cache.