### PR TITLE
update branch deploy to use `sha` instead of `ref`

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -10,6 +10,7 @@ permissions:
   deployments: write
   contents: write
   checks: read
+  statuses: read
 
 jobs:
   deploy:
@@ -18,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: github/branch-deploy@v9.9.1
+      - uses: github/branch-deploy@v9
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors
@@ -31,7 +32,7 @@ jobs:
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.branch-deploy.outputs.ref }}
+          ref: ${{ steps.branch-deploy.outputs.sha }}
 
       - name: setup node
         if: ${{ steps.branch-deploy.outputs.continue == 'true' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
-        uses: github/branch-deploy@v9.9.1
+        uses: github/branch-deploy@v9
         id: deployment-check
         with:
           merge_deploy_mode: "true"

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v9.9.1
+        uses: github/branch-deploy@v9
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pull request updates the `github/branch-deploy` action to use the `sha` value instead of `ref` for consistency and safety.