### PR TITLE
Enable Archived Prices

### DIFF
--- a/datasources/historical-prices.mjs
+++ b/datasources/historical-prices.mjs
@@ -5,7 +5,7 @@ class historicalPricesAPI extends WorkerKVSplit {
         super('historical_price_data', dataSource);
         this.addGameMode('pve');
         this.defaultDays = 7;
-        this.maxDays = 7;
+        this.maxDays = 30;
         this.itemLimitDays = 2;
     }
 
@@ -27,9 +27,9 @@ class historicalPricesAPI extends WorkerKVSplit {
         if (!prices) {
             return [];
         } 
-        /*if (days === this.maxDays) {
+        if (days === this.maxDays) {
             return prices;
-        }*/
+        }
         const cutoffTimestamp = new Date().setDate(new Date().getDate() - days);
         let dayFiltered = prices.filter(hp => hp.timestamp >= cutoffTimestamp);
         if (halfResults) {

--- a/resolvers/itemResolver.mjs
+++ b/resolvers/itemResolver.mjs
@@ -76,9 +76,9 @@ export default {
         historicalItemPrices(obj, args, context, info) {
             return context.util.paginate(context.data.worker.historicalPrice.getByItemId(context, info, args.id, args.days), args);
         },
-        /*archivedItemPrices(obj, args, context, info) {
+        archivedItemPrices(obj, args, context, info) {
             return context.util.paginate(context.data.worker.archivedPrice.getByItemId(context, info, args.id), args);
-        },*/
+        },
         armorMaterials(obj, args, context, info) {
             return context.data.worker.item.getArmorMaterials(context, info);
         },

--- a/schema-static.mjs
+++ b/schema-static.mjs
@@ -39,28 +39,6 @@ type Ammo {
   #attributes: AttributeCollection!
 }
 
-#type AttributeCollection {
-#  int: [AttributeInt]!
-#  float: [AttributeFloat]!
-#  string: [ItemAttribute]!
-#  boolean: [AttributeBoolean]!
-#}
-
-#type AttributeBoolean {
-#  name: String!
-#  value: Boolean!
-#}
-
-#type AttributeFloat {
-#  name: String!
-#  value: Float!
-#}
-
-#type AttributeInt {
-#  name: String!
-#  value: Int!
-#}
-
 type ArmorMaterial {
   id: String
   name: String
@@ -234,6 +212,8 @@ type HideoutStationLevel {
 type historicalPricePoint {
   price: Int
   priceMin: Int
+  offerCount: Int
+  offerCountMin: Int
   timestamp: String
 }
 
@@ -1395,7 +1375,7 @@ interface Vendor {
 type Query {
   achievements(lang: LanguageCode, limit: Int, offset: Int): [Achievement]!
   ammo(lang: LanguageCode, gameMode: GameMode, limit: Int, offset: Int): [Ammo]
-  #archivedItemPrices(id: ID!, limit: Int, offset: Int): [historicalPricePoint]!
+  archivedItemPrices(id: ID!, limit: Int, offset: Int): [historicalPricePoint]!
   barters(lang: LanguageCode, gameMode: GameMode, limit: Int, offset: Int): [Barter]
   bosses(lang: LanguageCode, gameMode: GameMode, name: [String!], limit: Int, offset: Int): [MobInfo]
   crafts(lang: LanguageCode, gameMode: GameMode, limit: Int, offset: Int): [Craft]


### PR DESCRIPTION
Enables the itemArchivedPrices query
- Must provide the `id` argument to specify which item's archived prices are being queried
- Archived prices contain summary price data for the queried item, grouped by day
- The most recent archived prices are 30 days in the past. In other words, on December 15, 2024, the most recent archived prices would be from November 15, 2024.
- Each item's archived prices include the minimum price scanned (`priceMin`), the average price scanned (`price`), the minimum offer count (`offerCountMin`), and the average offer count (`offerCount`).
- Offer count data is not available until the data beginning on November 20, 2024.

Modifies the itemHistoricalPrices query
- As before, historical prices reflect a summary of price data for the queried item, grouped by individual scans
- The maximum timespan for historical prices is now 30 days, meaning historical prices include data back until the point that archived data begins.
- When the `days` argument is not provided, it defaults to the previous maximum of 7 to preserve existing behavior
- The `offerCount` field has been added to indicate the number of offers available at the time of each scan