### PR TITLE
Increase max age of options response

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -204,7 +204,7 @@ export default {
             const optionsResponse = new Response(null, {
                 headers: {
                     'cache-control': 'public, max-age=2592000',
-                    'Access-Control-Max-Age': '600',
+                    'Access-Control-Max-Age': '86400',
                 },
             });
             setCors(optionsResponse, graphQLOptions.cors);

--- a/plugins/plugin-option-method.mjs
+++ b/plugins/plugin-option-method.mjs
@@ -7,7 +7,7 @@ export default function useOptionMethod() {
             const optionsResponse = new Response(null, {
                 headers: {
                     'cache-control': 'public, max-age=2592000',
-                    'Access-Control-Max-Age': '600',
+                    'Access-Control-Max-Age': '86400',
                 },
             });
             //setCors(optionsResponse, graphQLOptions.cors);


### PR DESCRIPTION
Tell browsers to cache the response for one day instead of 10 minutes.