### PR TITLE
bump the branch-deploy action to v11

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: github/branch-deploy@v10
+      - uses: github/branch-deploy@v11
         id: branch-deploy
         with:
           admins: the-hideout/core-contributors

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       # https://github.com/github/branch-deploy/blob/d3c24bd92505e623615b75ffdfac5ed5259adbdb/docs/merge-commit-strategy.md
       - name: deployment check
-        uses: github/branch-deploy@v10
+        uses: github/branch-deploy@v11
         id: deployment-check
         with:
           merge_deploy_mode: "true"

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: unlock on merge
-        uses: github/branch-deploy@v10
+        uses: github/branch-deploy@v11
         id: unlock-on-merge
         with:
           unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow


### PR DESCRIPTION
This pull request updates the `github/branch-deploy` action to the latest major release (`v11`) which is in pre-release and I want to test it out here.